### PR TITLE
refactor: 统一设置传参与统计请求模型，引入统一的 UiState 和 Actions 机制

### DIFF
--- a/app/src/main/java/yangfentuozi/batteryrecorder/data/history/SceneStatsComputer.kt
+++ b/app/src/main/java/yangfentuozi/batteryrecorder/data/history/SceneStatsComputer.kt
@@ -107,13 +107,8 @@ object SceneStatsComputer {
 
     fun compute(
         context: Context,
-        gamePackages: Set<String>,
-        recentFileCount: Int = ConfigConstants.DEF_SCENE_STATS_RECENT_FILE_COUNT,
-        recordIntervalMs: Long,
+        request: StatisticsRequest,
         currentDischargeFileName: String? = null,
-        predCurrentSessionWeightEnabled: Boolean = true,
-        predCurrentSessionWeightMaxX100: Int = 300,
-        predCurrentSessionWeightHalfLifeMin: Long = 30L
     ): SceneComputeResult? {
         val dataDir = File(
             File(context.dataDir, Constants.APP_POWER_DATA_PATH),
@@ -121,10 +116,15 @@ object SceneStatsComputer {
         )
         if (!dataDir.isDirectory) return null
 
-        val effectiveRecentFileCount = recentFileCount.coerceIn(
+        val effectiveRecentFileCount = request.sceneStatsRecentFileCount.coerceIn(
             ConfigConstants.MIN_SCENE_STATS_RECENT_FILE_COUNT,
             ConfigConstants.MAX_SCENE_STATS_RECENT_FILE_COUNT
         )
+        val gamePackages = request.gamePackages
+        val recordIntervalMs = request.recordIntervalMs
+        val predCurrentSessionWeightEnabled = request.predCurrentSessionWeightEnabled
+        val predCurrentSessionWeightMaxX100 = request.predCurrentSessionWeightMaxX100
+        val predCurrentSessionWeightHalfLifeMin = request.predCurrentSessionWeightHalfLifeMin
         val files = dataDir.listFiles()?.filter { it.isFile }
             ?.sortedByDescending { it.lastModified() }
             ?.take(effectiveRecentFileCount) ?: return null
@@ -134,13 +134,8 @@ object SceneStatsComputer {
         val cacheDir = File(context.cacheDir, "scene_stats")
         val cacheKey = buildCacheKey(
             files = files,
-            gamePackages = gamePackages,
-            recentFileCount = effectiveRecentFileCount,
-            recordIntervalMs = recordIntervalMs,
+            request = request,
             currentDischargeFileName = currentDischargeFileName,
-            predCurrentSessionWeightEnabled = predCurrentSessionWeightEnabled,
-            predCurrentSessionWeightMaxX100 = predCurrentSessionWeightMaxX100,
-            predCurrentSessionWeightHalfLifeMin = predCurrentSessionWeightHalfLifeMin
         )
         val cacheFile = File(cacheDir, "$cacheKey.csv")
         if (cacheFile.exists()) {
@@ -389,14 +384,15 @@ object SceneStatsComputer {
 
     private fun buildCacheKey(
         files: List<File>,
-        gamePackages: Set<String>,
-        recentFileCount: Int,
-        recordIntervalMs: Long,
+        request: StatisticsRequest,
         currentDischargeFileName: String?,
-        predCurrentSessionWeightEnabled: Boolean,
-        predCurrentSessionWeightMaxX100: Int,
-        predCurrentSessionWeightHalfLifeMin: Long
     ): String {
+        val gamePackages = request.gamePackages
+        val recentFileCount = request.sceneStatsRecentFileCount
+        val recordIntervalMs = request.recordIntervalMs
+        val predCurrentSessionWeightEnabled = request.predCurrentSessionWeightEnabled
+        val predCurrentSessionWeightMaxX100 = request.predCurrentSessionWeightMaxX100
+        val predCurrentSessionWeightHalfLifeMin = request.predCurrentSessionWeightHalfLifeMin
         val filesHash = files.joinToString(",") { "${it.name}:${it.lastModified()}" }.hashCode()
         val gamesHash = gamePackages.sorted().joinToString(",").hashCode()
         val currentNameHash = (currentDischargeFileName ?: "").hashCode()

--- a/app/src/main/java/yangfentuozi/batteryrecorder/data/history/StatisticsRequest.kt
+++ b/app/src/main/java/yangfentuozi/batteryrecorder/data/history/StatisticsRequest.kt
@@ -1,0 +1,12 @@
+package yangfentuozi.batteryrecorder.data.history
+
+import yangfentuozi.batteryrecorder.shared.config.ConfigConstants
+
+data class StatisticsRequest(
+    val gamePackages: Set<String> = emptySet(),
+    val sceneStatsRecentFileCount: Int = ConfigConstants.DEF_SCENE_STATS_RECENT_FILE_COUNT,
+    val recordIntervalMs: Long = ConfigConstants.DEF_RECORD_INTERVAL_MS,
+    val predCurrentSessionWeightEnabled: Boolean = ConfigConstants.DEF_PRED_CURRENT_SESSION_WEIGHT_ENABLED,
+    val predCurrentSessionWeightMaxX100: Int = ConfigConstants.DEF_PRED_CURRENT_SESSION_WEIGHT_MAX_X100,
+    val predCurrentSessionWeightHalfLifeMin: Long = ConfigConstants.DEF_PRED_CURRENT_SESSION_WEIGHT_HALF_LIFE_MIN
+)

--- a/app/src/main/java/yangfentuozi/batteryrecorder/ui/components/settings/sections/CalibrationSection.kt
+++ b/app/src/main/java/yangfentuozi/batteryrecorder/ui/components/settings/sections/CalibrationSection.kt
@@ -12,17 +12,14 @@ import yangfentuozi.batteryrecorder.ui.components.global.M3ESwitchWidget
 import yangfentuozi.batteryrecorder.ui.components.global.SplicedColumnGroup
 import yangfentuozi.batteryrecorder.ui.components.settings.SettingsItem
 import yangfentuozi.batteryrecorder.ui.dialog.settings.CalibrationDialog
+import yangfentuozi.batteryrecorder.ui.model.SettingsUiProps
 
 @Composable
 fun CalibrationSection(
-    dualCellEnabled: Boolean,
-    onDualCellChange: (Boolean) -> Unit,
-    dischargeDisplayPositive: Boolean,
-    onDischargeDisplayPositiveChange: (Boolean) -> Unit,
-    calibrationValue: Int,
-    serviceConnected: Boolean,
-    onCalibrationChange: (Int) -> Unit
+    props: SettingsUiProps
 ) {
+    val state = props.state
+    val actions = props.actions.calibration
     var showDialog by remember { mutableStateOf(false) }
 
     SplicedColumnGroup(
@@ -32,16 +29,16 @@ fun CalibrationSection(
         item {
             M3ESwitchWidget(
                 text = "串联双电芯",
-                checked = dualCellEnabled,
-                onCheckedChange = onDualCellChange
+                checked = state.dualCellEnabled,
+                onCheckedChange = actions.setDualCellEnabled
             )
         }
 
         item {
             M3ESwitchWidget(
                 text = "放电也显示正值",
-                checked = dischargeDisplayPositive,
-                onCheckedChange = onDischargeDisplayPositiveChange
+                checked = state.dischargeDisplayPositive,
+                onCheckedChange = actions.setDischargeDisplayPositiveEnabled
             )
         }
 
@@ -55,16 +52,16 @@ fun CalibrationSection(
 
     if (showDialog) {
         CalibrationDialog(
-            currentValue = calibrationValue,
-            dualCellEnabled = dualCellEnabled,
-            serviceConnected = serviceConnected,
+            currentValue = state.calibrationValue,
+            dualCellEnabled = state.dualCellEnabled,
+            serviceConnected = props.serviceConnected,
             onDismiss = { showDialog = false },
             onSave = { value ->
-                onCalibrationChange(value)
+                actions.setCalibrationValue(value)
                 showDialog = false
             },
             onReset = {
-                onCalibrationChange(-1)
+                actions.setCalibrationValue(-1)
                 showDialog = false
             }
         )

--- a/app/src/main/java/yangfentuozi/batteryrecorder/ui/components/settings/sections/PredictionSection.kt
+++ b/app/src/main/java/yangfentuozi/batteryrecorder/ui/components/settings/sections/PredictionSection.kt
@@ -14,21 +14,14 @@ import yangfentuozi.batteryrecorder.ui.components.global.SplicedColumnGroup
 import yangfentuozi.batteryrecorder.ui.components.settings.SettingsItem
 import yangfentuozi.batteryrecorder.ui.dialog.settings.CurrentSessionWeightDialog
 import yangfentuozi.batteryrecorder.ui.dialog.settings.SceneStatsRecentFileCountDialog
+import yangfentuozi.batteryrecorder.ui.model.SettingsUiProps
 
 @Composable
 fun PredictionSection(
-    gamePackages: Set<String>,
-    gameBlacklist: Set<String>,
-    onGamePackagesChange: (selected: Set<String>, detectedGamePkgs: Set<String>) -> Unit,
-    sceneStatsRecentFileCount: Int,
-    onSceneStatsRecentFileCountChange: (Int) -> Unit,
-    currentSessionWeightEnabled: Boolean,
-    onCurrentSessionWeightEnabledChange: (Boolean) -> Unit,
-    currentSessionWeightMaxX100: Int,
-    onCurrentSessionWeightMaxX100Change: (Int) -> Unit,
-    currentSessionWeightHalfLifeMin: Long,
-    onCurrentSessionWeightHalfLifeMinChange: (Long) -> Unit
+    props: SettingsUiProps
 ) {
+    val state = props.state
+    val actions = props.actions.prediction
     var showWeightDialog by remember { mutableStateOf(false) }
     var showRecentCountDialog by remember { mutableStateOf(false) }
 
@@ -38,30 +31,30 @@ fun PredictionSection(
     ) {
         item {
             PredictionGameFilterItem(
-                gamePackages = gamePackages,
-                gameBlacklist = gameBlacklist,
-                onGamePackagesChange = onGamePackagesChange
+                gamePackages = state.gamePackages,
+                gameBlacklist = state.gameBlacklist,
+                onGamePackagesChange = actions.setGamePackages
             )
         }
 
         item {
             SettingsItem(
                 title = "样本次数",
-                summary = "最近 ${sceneStatsRecentFileCount} 次"
+                summary = "最近 ${state.sceneStatsRecentFileCount} 次"
             ) { showRecentCountDialog = true }
         }
 
         item {
             M3ESwitchWidget(
                 text = "当次记录加权",
-                checked = currentSessionWeightEnabled,
-                onCheckedChange = onCurrentSessionWeightEnabledChange
+                checked = state.predCurrentSessionWeightEnabled,
+                onCheckedChange = actions.setPredCurrentSessionWeightEnabled
             )
         }
 
         item {
-            val maxX = currentSessionWeightMaxX100 / 100.0
-            val summary = "最大 %.2fx / 半衰期 %d 分钟".format(maxX, currentSessionWeightHalfLifeMin)
+            val maxX = state.predCurrentSessionWeightMaxX100 / 100.0
+            val summary = "最大 %.2fx / 半衰期 %d 分钟".format(maxX, state.predCurrentSessionWeightHalfLifeMin)
             SettingsItem(
                 title = "加权强度",
                 summary = summary
@@ -71,14 +64,14 @@ fun PredictionSection(
 
     if (showRecentCountDialog) {
         SceneStatsRecentFileCountDialog(
-            currentValue = sceneStatsRecentFileCount,
+            currentValue = state.sceneStatsRecentFileCount,
             onDismiss = { showRecentCountDialog = false },
             onSave = { count ->
-                onSceneStatsRecentFileCountChange(count)
+                actions.setSceneStatsRecentFileCount(count)
                 showRecentCountDialog = false
             },
             onReset = {
-                onSceneStatsRecentFileCountChange(ConfigConstants.DEF_SCENE_STATS_RECENT_FILE_COUNT)
+                actions.setSceneStatsRecentFileCount(ConfigConstants.DEF_SCENE_STATS_RECENT_FILE_COUNT)
                 showRecentCountDialog = false
             }
         )
@@ -86,17 +79,17 @@ fun PredictionSection(
 
     if (showWeightDialog) {
         CurrentSessionWeightDialog(
-            currentMaxX100 = currentSessionWeightMaxX100,
-            currentHalfLifeMin = currentSessionWeightHalfLifeMin,
+            currentMaxX100 = state.predCurrentSessionWeightMaxX100,
+            currentHalfLifeMin = state.predCurrentSessionWeightHalfLifeMin,
             onDismiss = { showWeightDialog = false },
             onSave = { maxX100, halfLifeMin ->
-                onCurrentSessionWeightMaxX100Change(maxX100)
-                onCurrentSessionWeightHalfLifeMinChange(halfLifeMin)
+                actions.setPredCurrentSessionWeightMaxX100(maxX100)
+                actions.setPredCurrentSessionWeightHalfLifeMin(halfLifeMin)
                 showWeightDialog = false
             },
             onReset = {
-                onCurrentSessionWeightMaxX100Change(ConfigConstants.DEF_PRED_CURRENT_SESSION_WEIGHT_MAX_X100)
-                onCurrentSessionWeightHalfLifeMinChange(ConfigConstants.DEF_PRED_CURRENT_SESSION_WEIGHT_HALF_LIFE_MIN)
+                actions.setPredCurrentSessionWeightMaxX100(ConfigConstants.DEF_PRED_CURRENT_SESSION_WEIGHT_MAX_X100)
+                actions.setPredCurrentSessionWeightHalfLifeMin(ConfigConstants.DEF_PRED_CURRENT_SESSION_WEIGHT_HALF_LIFE_MIN)
                 showWeightDialog = false
             }
         )

--- a/app/src/main/java/yangfentuozi/batteryrecorder/ui/components/settings/sections/ServerSection.kt
+++ b/app/src/main/java/yangfentuozi/batteryrecorder/ui/components/settings/sections/ServerSection.kt
@@ -15,21 +15,15 @@ import yangfentuozi.batteryrecorder.ui.dialog.settings.BatchSizeDialog
 import yangfentuozi.batteryrecorder.ui.dialog.settings.RecordIntervalDialog
 import yangfentuozi.batteryrecorder.ui.dialog.settings.SegmentDurationDialog
 import yangfentuozi.batteryrecorder.ui.dialog.settings.WriteLatencyDialog
+import yangfentuozi.batteryrecorder.ui.model.SettingsUiProps
 import kotlin.math.round
 
 @Composable
 fun ServerSection(
-    recordIntervalMs: Long,
-    onRecordIntervalChange: (Long) -> Unit,
-    writeLatencyMs: Long,
-    onWriteLatencyChange: (Long) -> Unit,
-    batchSize: Int,
-    onBatchSizeChange: (Int) -> Unit,
-    recordScreenOffEnabled: Boolean,
-    onRecordScreenOffChange: (Boolean) -> Unit,
-    segmentDurationMin: Long,
-    onSegmentDurationChange: (Long) -> Unit
+    props: SettingsUiProps
 ) {
+    val state = props.state
+    val actions = props.actions.server
     var showRecordIntervalDialog by remember { mutableStateOf(false) }
     var showWriteLatencyDialog by remember { mutableStateOf(false) }
     var showBatchSizeDialog by remember { mutableStateOf(false) }
@@ -42,37 +36,37 @@ fun ServerSection(
         item {
             M3ESwitchWidget(
                 text = "息屏记录",
-                checked = recordScreenOffEnabled,
-                onCheckedChange = onRecordScreenOffChange
+                checked = state.recordScreenOffEnabled,
+                onCheckedChange = actions.setScreenOffRecordEnabled
             )
         }
 
         item {
             SettingsItem(
                 title = "采样间隔",
-                summary = "${"%.1f".format(recordIntervalMs / 1000.0)} 秒"
+                summary = "${"%.1f".format(state.recordIntervalMs / 1000.0)} 秒"
             ) { showRecordIntervalDialog = true }
         }
 
         item {
             SettingsItem(
                 title = "写入延迟",
-                summary = "${"%.1f".format(writeLatencyMs / 1000.0)} 秒"
+                summary = "${"%.1f".format(state.writeLatencyMs / 1000.0)} 秒"
             ) { showWriteLatencyDialog = true }
         }
 
         item {
             SettingsItem(
                 title = "批量大小",
-                summary = "$batchSize 条"
+                summary = "${state.batchSize} 条"
             ) { showBatchSizeDialog = true }
         }
 
         item {
-            val summary = if (segmentDurationMin == 0L) {
+            val summary = if (state.segmentDurationMin == 0L) {
                 "不按时间分段"
             } else {
-                "$segmentDurationMin 分钟"
+                "${state.segmentDurationMin} 分钟"
             }
             SettingsItem(
                 title = "分段时间",
@@ -84,15 +78,15 @@ fun ServerSection(
     // 采样间隔对话框
     if (showRecordIntervalDialog) {
         RecordIntervalDialog(
-            currentValueMs = recordIntervalMs,
+            currentValueMs = state.recordIntervalMs,
             onDismiss = { showRecordIntervalDialog = false },
             onSave = { value ->
                 val roundedValue = (round(value / 100.0) * 100).toLong()
-                onRecordIntervalChange(roundedValue)
+                actions.setRecordIntervalMs(roundedValue)
                 showRecordIntervalDialog = false
             },
             onReset = {
-                onRecordIntervalChange(1000)
+                actions.setRecordIntervalMs(1000)
                 showRecordIntervalDialog = false
             }
         )
@@ -101,15 +95,15 @@ fun ServerSection(
     // 写入延迟对话框
     if (showWriteLatencyDialog) {
         WriteLatencyDialog(
-            currentValueMs = writeLatencyMs,
+            currentValueMs = state.writeLatencyMs,
             onDismiss = { showWriteLatencyDialog = false },
             onSave = { value ->
                 val roundedValue = (round(value / 100.0) * 100).toLong()
-                onWriteLatencyChange(roundedValue)
+                actions.setWriteLatencyMs(roundedValue)
                 showWriteLatencyDialog = false
             },
             onReset = {
-                onWriteLatencyChange(30000)
+                actions.setWriteLatencyMs(30000)
                 showWriteLatencyDialog = false
             }
         )
@@ -118,14 +112,14 @@ fun ServerSection(
     // 批量大小对话框
     if (showBatchSizeDialog) {
         BatchSizeDialog(
-            currentValue = batchSize,
+            currentValue = state.batchSize,
             onDismiss = { showBatchSizeDialog = false },
             onSave = { value ->
-                onBatchSizeChange(value)
+                actions.setBatchSize(value)
                 showBatchSizeDialog = false
             },
             onReset = {
-                onBatchSizeChange(200)
+                actions.setBatchSize(200)
                 showBatchSizeDialog = false
             }
         )
@@ -134,14 +128,14 @@ fun ServerSection(
     // 分段时间对话框
     if (showSegmentDurationDialog) {
         SegmentDurationDialog(
-            currentValueMin = segmentDurationMin,
+            currentValueMin = state.segmentDurationMin,
             onDismiss = { showSegmentDurationDialog = false },
             onSave = { value ->
-                onSegmentDurationChange(value)
+                actions.setSegmentDurationMin(value)
                 showSegmentDurationDialog = false
             },
             onReset = {
-                onSegmentDurationChange(1440)
+                actions.setSegmentDurationMin(1440)
                 showSegmentDurationDialog = false
             }
         )

--- a/app/src/main/java/yangfentuozi/batteryrecorder/ui/model/SettingsActions.kt
+++ b/app/src/main/java/yangfentuozi/batteryrecorder/ui/model/SettingsActions.kt
@@ -1,0 +1,29 @@
+package yangfentuozi.batteryrecorder.ui.model
+
+data class CalibrationActions(
+    val setDualCellEnabled: (Boolean) -> Unit,
+    val setDischargeDisplayPositiveEnabled: (Boolean) -> Unit,
+    val setCalibrationValue: (Int) -> Unit
+)
+
+data class ServerActions(
+    val setRecordIntervalMs: (Long) -> Unit,
+    val setWriteLatencyMs: (Long) -> Unit,
+    val setBatchSize: (Int) -> Unit,
+    val setScreenOffRecordEnabled: (Boolean) -> Unit,
+    val setSegmentDurationMin: (Long) -> Unit
+)
+
+data class PredictionActions(
+    val setGamePackages: (Set<String>, Set<String>) -> Unit,
+    val setSceneStatsRecentFileCount: (Int) -> Unit,
+    val setPredCurrentSessionWeightEnabled: (Boolean) -> Unit,
+    val setPredCurrentSessionWeightMaxX100: (Int) -> Unit,
+    val setPredCurrentSessionWeightHalfLifeMin: (Long) -> Unit
+)
+
+data class SettingsActions(
+    val calibration: CalibrationActions,
+    val server: ServerActions,
+    val prediction: PredictionActions
+)

--- a/app/src/main/java/yangfentuozi/batteryrecorder/ui/model/SettingsUiProps.kt
+++ b/app/src/main/java/yangfentuozi/batteryrecorder/ui/model/SettingsUiProps.kt
@@ -1,0 +1,7 @@
+package yangfentuozi.batteryrecorder.ui.model
+
+data class SettingsUiProps(
+    val state: SettingsUiState,
+    val actions: SettingsActions,
+    val serviceConnected: Boolean
+)

--- a/app/src/main/java/yangfentuozi/batteryrecorder/ui/model/SettingsUiState.kt
+++ b/app/src/main/java/yangfentuozi/batteryrecorder/ui/model/SettingsUiState.kt
@@ -1,0 +1,20 @@
+package yangfentuozi.batteryrecorder.ui.model
+
+import yangfentuozi.batteryrecorder.shared.config.ConfigConstants
+
+data class SettingsUiState(
+    val dualCellEnabled: Boolean = ConfigConstants.DEF_DUAL_CELL_ENABLED,
+    val dischargeDisplayPositive: Boolean = ConfigConstants.DEF_DISCHARGE_DISPLAY_POSITIVE,
+    val calibrationValue: Int = ConfigConstants.DEF_CALIBRATION_VALUE,
+    val recordIntervalMs: Long = ConfigConstants.DEF_RECORD_INTERVAL_MS,
+    val writeLatencyMs: Long = ConfigConstants.DEF_WRITE_LATENCY_MS,
+    val batchSize: Int = ConfigConstants.DEF_BATCH_SIZE,
+    val recordScreenOffEnabled: Boolean = ConfigConstants.DEF_SCREEN_OFF_RECORD_ENABLED,
+    val segmentDurationMin: Long = ConfigConstants.DEF_SEGMENT_DURATION_MIN,
+    val gamePackages: Set<String> = emptySet(),
+    val gameBlacklist: Set<String> = emptySet(),
+    val sceneStatsRecentFileCount: Int = ConfigConstants.DEF_SCENE_STATS_RECENT_FILE_COUNT,
+    val predCurrentSessionWeightEnabled: Boolean = ConfigConstants.DEF_PRED_CURRENT_SESSION_WEIGHT_ENABLED,
+    val predCurrentSessionWeightMaxX100: Int = ConfigConstants.DEF_PRED_CURRENT_SESSION_WEIGHT_MAX_X100,
+    val predCurrentSessionWeightHalfLifeMin: Long = ConfigConstants.DEF_PRED_CURRENT_SESSION_WEIGHT_HALF_LIFE_MIN
+)

--- a/app/src/main/java/yangfentuozi/batteryrecorder/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/yangfentuozi/batteryrecorder/ui/screens/home/HomeScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -70,16 +71,13 @@ fun HomeScreen(
     val currentRecord by viewModel.currentRecord.collectAsState()
     val liveStatus by liveRecordViewModel.lastStatus.collectAsState()
 
-    // 读取设置值
-    val dualCellEnabled by settingsViewModel.dualCellEnabled.collectAsState()
-    val calibrationValue by settingsViewModel.calibrationValue.collectAsState()
-    val intervalMs by settingsViewModel.recordIntervalMs.collectAsState()
-    val dischargeDisplayPositive by settingsViewModel.dischargeDisplayPositive.collectAsState()
-    val gamePackages by settingsViewModel.gamePackages.collectAsState()
-    val sceneStatsRecentFileCount by settingsViewModel.sceneStatsRecentFileCount.collectAsState()
-    val predCurrentSessionWeightEnabled by settingsViewModel.predCurrentSessionWeightEnabled.collectAsState()
-    val predCurrentSessionWeightMaxX100 by settingsViewModel.predCurrentSessionWeightMaxX100.collectAsState()
-    val predCurrentSessionWeightHalfLifeMin by settingsViewModel.predCurrentSessionWeightHalfLifeMin.collectAsState()
+    val settingsState by settingsViewModel.settingsUiState.collectAsState()
+    val statisticsRequest by settingsViewModel.statisticsRequest.collectAsState()
+    val latestStatisticsRequest by rememberUpdatedState(statisticsRequest)
+    val dualCellEnabled = settingsState.dualCellEnabled
+    val calibrationValue = settingsState.calibrationValue
+    val intervalMs = settingsState.recordIntervalMs
+    val dischargeDisplayPositive = settingsState.dischargeDisplayPositive
 
     // 场景统计和预测
     val sceneStats by viewModel.sceneStats.collectAsState()
@@ -95,12 +93,7 @@ fun HomeScreen(
             override fun onChangedCurrRecordsFile() {
                 viewModel.forceRefreshStatistics(
                     context = context,
-                    gamePackages = gamePackages,
-                    sceneStatsRecentFileCount = sceneStatsRecentFileCount,
-                    recordIntervalMs = intervalMs,
-                    predCurrentSessionWeightEnabled = predCurrentSessionWeightEnabled,
-                    predCurrentSessionWeightMaxX100 = predCurrentSessionWeightMaxX100,
-                    predCurrentSessionWeightHalfLifeMin = predCurrentSessionWeightHalfLifeMin
+                    request = latestStatisticsRequest
                 )
             }
         }
@@ -113,12 +106,7 @@ fun HomeScreen(
                 delay(1500)
                 viewModel.refreshStatistics(
                     context = context,
-                    gamePackages = gamePackages,
-                    sceneStatsRecentFileCount = sceneStatsRecentFileCount,
-                    recordIntervalMs = intervalMs,
-                    predCurrentSessionWeightEnabled = predCurrentSessionWeightEnabled,
-                    predCurrentSessionWeightMaxX100 = predCurrentSessionWeightMaxX100,
-                    predCurrentSessionWeightHalfLifeMin = predCurrentSessionWeightHalfLifeMin
+                    request = statisticsRequest
                 )
             }
         }
@@ -135,12 +123,7 @@ fun HomeScreen(
                 Lifecycle.Event.ON_START -> {
                     viewModel.refreshStatistics(
                         context = context,
-                        gamePackages = gamePackages,
-                        sceneStatsRecentFileCount = sceneStatsRecentFileCount,
-                        recordIntervalMs = intervalMs,
-                        predCurrentSessionWeightEnabled = predCurrentSessionWeightEnabled,
-                        predCurrentSessionWeightMaxX100 = predCurrentSessionWeightMaxX100,
-                        predCurrentSessionWeightHalfLifeMin = predCurrentSessionWeightHalfLifeMin
+                        request = latestStatisticsRequest
                     )
                     Service.service?.registerRecordListener(listener)
                 }
@@ -169,12 +152,7 @@ fun HomeScreen(
                     onRefreshClick = {
                         viewModel.forceRefreshStatistics(
                             context = context,
-                            gamePackages = gamePackages,
-                            sceneStatsRecentFileCount = sceneStatsRecentFileCount,
-                            recordIntervalMs = intervalMs,
-                            predCurrentSessionWeightEnabled = predCurrentSessionWeightEnabled,
-                            predCurrentSessionWeightMaxX100 = predCurrentSessionWeightMaxX100,
-                            predCurrentSessionWeightHalfLifeMin = predCurrentSessionWeightHalfLifeMin
+                            request = statisticsRequest
                         )
                     },
                     showStopServer = serviceConnected

--- a/app/src/main/java/yangfentuozi/batteryrecorder/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/yangfentuozi/batteryrecorder/ui/screens/settings/SettingsScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.unit.dp
@@ -24,6 +25,11 @@ import yangfentuozi.batteryrecorder.ipc.Service
 import yangfentuozi.batteryrecorder.ui.components.settings.sections.CalibrationSection
 import yangfentuozi.batteryrecorder.ui.components.settings.sections.PredictionSection
 import yangfentuozi.batteryrecorder.ui.components.settings.sections.ServerSection
+import yangfentuozi.batteryrecorder.ui.model.CalibrationActions
+import yangfentuozi.batteryrecorder.ui.model.PredictionActions
+import yangfentuozi.batteryrecorder.ui.model.ServerActions
+import yangfentuozi.batteryrecorder.ui.model.SettingsActions
+import yangfentuozi.batteryrecorder.ui.model.SettingsUiProps
 import yangfentuozi.batteryrecorder.ui.viewmodel.SettingsViewModel
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
@@ -32,22 +38,36 @@ fun SettingsScreen(
     settingsViewModel: SettingsViewModel,
     onNavigateBack: () -> Unit = {}
 ) {
-    // 读取设置值
-    val dualCellEnabled by settingsViewModel.dualCellEnabled.collectAsState()
-    val dischargeDisplayPositive by settingsViewModel.dischargeDisplayPositive.collectAsState()
-    val calibrationValue by settingsViewModel.calibrationValue.collectAsState()
-    val intervalMs by settingsViewModel.recordIntervalMs.collectAsState()
-    val writeLatencyMs by settingsViewModel.writeLatencyMs.collectAsState()
-    val batchSize by settingsViewModel.batchSize.collectAsState()
-    val recordScreenOffEnabled by settingsViewModel.screenOffRecord.collectAsState()
-    val segmentDurationMin by settingsViewModel.segmentDurationMin.collectAsState()
-    val gamePackages by settingsViewModel.gamePackages.collectAsState()
-    val gameBlacklist by settingsViewModel.gameBlacklist.collectAsState()
-    val sceneStatsRecentFileCount by settingsViewModel.sceneStatsRecentFileCount.collectAsState()
-    val predCurrentSessionWeightEnabled by settingsViewModel.predCurrentSessionWeightEnabled.collectAsState()
-    val predCurrentSessionWeightMaxX100 by settingsViewModel.predCurrentSessionWeightMaxX100.collectAsState()
-    val predCurrentSessionWeightHalfLifeMin by settingsViewModel.predCurrentSessionWeightHalfLifeMin.collectAsState()
+    val settingsState by settingsViewModel.settingsUiState.collectAsState()
     val serviceConnected = Service.service != null
+    val actions = remember(settingsViewModel) {
+        SettingsActions(
+            calibration = CalibrationActions(
+                setDualCellEnabled = settingsViewModel::setDualCellEnabled,
+                setDischargeDisplayPositiveEnabled = settingsViewModel::setDischargeDisplayPositiveEnabled,
+                setCalibrationValue = settingsViewModel::setCalibrationValue
+            ),
+            server = ServerActions(
+                setRecordIntervalMs = settingsViewModel::setRecordIntervalMs,
+                setWriteLatencyMs = settingsViewModel::setWriteLatencyMs,
+                setBatchSize = settingsViewModel::setBatchSize,
+                setScreenOffRecordEnabled = settingsViewModel::setScreenOffRecordEnabled,
+                setSegmentDurationMin = settingsViewModel::setSegmentDurationMin
+            ),
+            prediction = PredictionActions(
+                setGamePackages = settingsViewModel::setGamePackages,
+                setSceneStatsRecentFileCount = settingsViewModel::setSceneStatsRecentFileCount,
+                setPredCurrentSessionWeightEnabled = settingsViewModel::setPredCurrentSessionWeightEnabled,
+                setPredCurrentSessionWeightMaxX100 = settingsViewModel::setPredCurrentSessionWeightMaxX100,
+                setPredCurrentSessionWeightHalfLifeMin = settingsViewModel::setPredCurrentSessionWeightHalfLifeMin
+            )
+        )
+    }
+    val props = SettingsUiProps(
+        state = settingsState,
+        actions = actions,
+        serviceConnected = serviceConnected
+    )
 
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
 
@@ -73,47 +93,16 @@ fun SettingsScreen(
         ) {
             item {
                 // 校准设置
-                CalibrationSection(
-                    dualCellEnabled = dualCellEnabled,
-                    onDualCellChange = settingsViewModel::setDualCellEnabled,
-                    dischargeDisplayPositive = dischargeDisplayPositive,
-                    onDischargeDisplayPositiveChange = settingsViewModel::setDischargeDisplayPositiveEnabled,
-                    calibrationValue = calibrationValue,
-                    serviceConnected = serviceConnected,
-                    onCalibrationChange = settingsViewModel::setCalibrationValue
-                )
+                CalibrationSection(props = props)
             }
             item { Spacer(modifier = Modifier.size(16.dp)) }
             item {
                 // 服务器设置
-                ServerSection(
-                    recordIntervalMs = intervalMs,
-                    onRecordIntervalChange = settingsViewModel::setRecordIntervalMs,
-                    writeLatencyMs = writeLatencyMs,
-                    onWriteLatencyChange = settingsViewModel::setWriteLatencyMs,
-                    batchSize = batchSize,
-                    onBatchSizeChange = settingsViewModel::setBatchSize,
-                    recordScreenOffEnabled = recordScreenOffEnabled,
-                    onRecordScreenOffChange = settingsViewModel::setScreenOffRecordEnabled,
-                    segmentDurationMin = segmentDurationMin,
-                    onSegmentDurationChange = settingsViewModel::setSegmentDurationMin,
-                )
+                ServerSection(props = props)
             }
             item { Spacer(modifier = Modifier.size(16.dp)) }
             item {
-                PredictionSection(
-                    gamePackages = gamePackages,
-                    gameBlacklist = gameBlacklist,
-                    onGamePackagesChange = settingsViewModel::setGamePackages,
-                    sceneStatsRecentFileCount = sceneStatsRecentFileCount,
-                    onSceneStatsRecentFileCountChange = settingsViewModel::setSceneStatsRecentFileCount,
-                    currentSessionWeightEnabled = predCurrentSessionWeightEnabled,
-                    onCurrentSessionWeightEnabledChange = settingsViewModel::setPredCurrentSessionWeightEnabled,
-                    currentSessionWeightMaxX100 = predCurrentSessionWeightMaxX100,
-                    onCurrentSessionWeightMaxX100Change = settingsViewModel::setPredCurrentSessionWeightMaxX100,
-                    currentSessionWeightHalfLifeMin = predCurrentSessionWeightHalfLifeMin,
-                    onCurrentSessionWeightHalfLifeMinChange = settingsViewModel::setPredCurrentSessionWeightHalfLifeMin
-                )
+                PredictionSection(props = props)
             }
         }
     }

--- a/app/src/main/java/yangfentuozi/batteryrecorder/ui/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/yangfentuozi/batteryrecorder/ui/viewmodel/MainViewModel.kt
@@ -20,9 +20,9 @@ import yangfentuozi.batteryrecorder.data.history.HistorySummary
 import yangfentuozi.batteryrecorder.data.history.PredictionResult
 import yangfentuozi.batteryrecorder.data.history.SceneStats
 import yangfentuozi.batteryrecorder.data.history.SceneStatsComputer
+import yangfentuozi.batteryrecorder.data.history.StatisticsRequest
 import yangfentuozi.batteryrecorder.data.history.SyncUtil
 import yangfentuozi.batteryrecorder.ipc.Service
-import yangfentuozi.batteryrecorder.shared.config.ConfigConstants
 import yangfentuozi.batteryrecorder.shared.data.BatteryStatus
 
 class MainViewModel : ViewModel() {
@@ -106,34 +106,19 @@ class MainViewModel : ViewModel() {
 
     fun loadStatistics(
         context: Context,
-        gamePackages: Set<String> = emptySet(),
-        sceneStatsRecentFileCount: Int = ConfigConstants.DEF_SCENE_STATS_RECENT_FILE_COUNT,
-        recordIntervalMs: Long = 1000L,
-        predCurrentSessionWeightEnabled: Boolean = true,
-        predCurrentSessionWeightMaxX100: Int = 300,
-        predCurrentSessionWeightHalfLifeMin: Long = 30L
+        request: StatisticsRequest = StatisticsRequest()
     ) {
         if (_isLoadingStats.value) return
 
         startLoadStatistics(
             context = context,
-            gamePackages = gamePackages,
-            sceneStatsRecentFileCount = sceneStatsRecentFileCount,
-            recordIntervalMs = recordIntervalMs,
-            predCurrentSessionWeightEnabled = predCurrentSessionWeightEnabled,
-            predCurrentSessionWeightMaxX100 = predCurrentSessionWeightMaxX100,
-            predCurrentSessionWeightHalfLifeMin = predCurrentSessionWeightHalfLifeMin
+            request = request
         )
     }
 
     fun refreshStatistics(
         context: Context,
-        gamePackages: Set<String> = emptySet(),
-        sceneStatsRecentFileCount: Int = ConfigConstants.DEF_SCENE_STATS_RECENT_FILE_COUNT,
-        recordIntervalMs: Long = 1000L,
-        predCurrentSessionWeightEnabled: Boolean = true,
-        predCurrentSessionWeightMaxX100: Int = 300,
-        predCurrentSessionWeightHalfLifeMin: Long = 30L
+        request: StatisticsRequest = StatisticsRequest()
     ) {
         if (_isLoadingStats.value) return
         _chargeSummary.value = null
@@ -143,23 +128,13 @@ class MainViewModel : ViewModel() {
         _prediction.value = null
         loadStatistics(
             context = context,
-            gamePackages = gamePackages,
-            sceneStatsRecentFileCount = sceneStatsRecentFileCount,
-            recordIntervalMs = recordIntervalMs,
-            predCurrentSessionWeightEnabled = predCurrentSessionWeightEnabled,
-            predCurrentSessionWeightMaxX100 = predCurrentSessionWeightMaxX100,
-            predCurrentSessionWeightHalfLifeMin = predCurrentSessionWeightHalfLifeMin
+            request = request
         )
     }
 
     fun forceRefreshStatistics(
         context: Context,
-        gamePackages: Set<String> = emptySet(),
-        sceneStatsRecentFileCount: Int = ConfigConstants.DEF_SCENE_STATS_RECENT_FILE_COUNT,
-        recordIntervalMs: Long = 1000L,
-        predCurrentSessionWeightEnabled: Boolean = true,
-        predCurrentSessionWeightMaxX100: Int = 300,
-        predCurrentSessionWeightHalfLifeMin: Long = 30L
+        request: StatisticsRequest = StatisticsRequest()
     ) {
         statisticsJob?.cancel()
         _chargeSummary.value = null
@@ -169,12 +144,7 @@ class MainViewModel : ViewModel() {
         _prediction.value = null
         startLoadStatistics(
             context = context,
-            gamePackages = gamePackages,
-            sceneStatsRecentFileCount = sceneStatsRecentFileCount,
-            recordIntervalMs = recordIntervalMs,
-            predCurrentSessionWeightEnabled = predCurrentSessionWeightEnabled,
-            predCurrentSessionWeightMaxX100 = predCurrentSessionWeightMaxX100,
-            predCurrentSessionWeightHalfLifeMin = predCurrentSessionWeightHalfLifeMin
+            request = request
         )
     }
 
@@ -215,12 +185,7 @@ class MainViewModel : ViewModel() {
 
     private fun startLoadStatistics(
         context: Context,
-        gamePackages: Set<String>,
-        sceneStatsRecentFileCount: Int,
-        recordIntervalMs: Long,
-        predCurrentSessionWeightEnabled: Boolean,
-        predCurrentSessionWeightMaxX100: Int,
-        predCurrentSessionWeightHalfLifeMin: Long
+        request: StatisticsRequest
     ) {
         val generation = (++statisticsGeneration)
         _isLoadingStats.value = true
@@ -254,13 +219,8 @@ class MainViewModel : ViewModel() {
                         ?.name
                     SceneStatsComputer.compute(
                         context = context,
-                        gamePackages = gamePackages,
-                        recentFileCount = sceneStatsRecentFileCount,
-                        recordIntervalMs = recordIntervalMs,
+                        request = request,
                         currentDischargeFileName = currentDischargeFileName,
-                        predCurrentSessionWeightEnabled = predCurrentSessionWeightEnabled,
-                        predCurrentSessionWeightMaxX100 = predCurrentSessionWeightMaxX100,
-                        predCurrentSessionWeightHalfLifeMin = predCurrentSessionWeightHalfLifeMin
                     )
                 }
 

--- a/app/src/main/java/yangfentuozi/batteryrecorder/ui/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/yangfentuozi/batteryrecorder/ui/viewmodel/SettingsViewModel.kt
@@ -9,9 +9,11 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import yangfentuozi.batteryrecorder.data.history.StatisticsRequest
 import yangfentuozi.batteryrecorder.ipc.Service
 import yangfentuozi.batteryrecorder.shared.config.Config
 import yangfentuozi.batteryrecorder.shared.config.ConfigConstants
+import yangfentuozi.batteryrecorder.ui.model.SettingsUiState
 
 class SettingsViewModel : ViewModel() {
     private lateinit var prefs: SharedPreferences
@@ -74,6 +76,12 @@ class SettingsViewModel : ViewModel() {
     private val _predCurrentSessionWeightHalfLifeMin =
         MutableStateFlow(ConfigConstants.DEF_PRED_CURRENT_SESSION_WEIGHT_HALF_LIFE_MIN)
     val predCurrentSessionWeightHalfLifeMin: StateFlow<Long> = _predCurrentSessionWeightHalfLifeMin.asStateFlow()
+
+    private val _settingsUiState = MutableStateFlow(SettingsUiState())
+    val settingsUiState: StateFlow<SettingsUiState> = _settingsUiState.asStateFlow()
+
+    private val _statisticsRequest = MutableStateFlow(StatisticsRequest())
+    val statisticsRequest: StateFlow<StatisticsRequest> = _statisticsRequest.asStateFlow()
 
     private lateinit var serverConfig: Config
 
@@ -202,6 +210,8 @@ class SettingsViewModel : ViewModel() {
                 ConfigConstants.MIN_PRED_CURRENT_SESSION_WEIGHT_HALF_LIFE_MIN,
                 ConfigConstants.MAX_PRED_CURRENT_SESSION_WEIGHT_HALF_LIFE_MIN
             )
+
+        refreshCombinedState()
     }
 
     /**
@@ -211,6 +221,7 @@ class SettingsViewModel : ViewModel() {
         viewModelScope.launch {
             prefs.edit { putBoolean(ConfigConstants.KEY_DUAL_CELL_ENABLED, enabled) }
             _dualCellEnabled.value = enabled
+            refreshCombinedState()
         }
     }
 
@@ -221,6 +232,7 @@ class SettingsViewModel : ViewModel() {
         viewModelScope.launch {
             prefs.edit { putBoolean(ConfigConstants.KEY_DISCHARGE_DISPLAY_POSITIVE, enabled) }
             _dischargeDisplayPositive.value = enabled
+            refreshCombinedState()
         }
     }
 
@@ -230,6 +242,7 @@ class SettingsViewModel : ViewModel() {
         viewModelScope.launch {
             prefs.edit { putInt(ConfigConstants.KEY_CALIBRATION_VALUE, finalValue) }
             _calibrationValue.value = finalValue
+            refreshCombinedState()
         }
     }
 
@@ -244,6 +257,7 @@ class SettingsViewModel : ViewModel() {
             _recordIntervalMs.value = finalValue
             serverConfig = serverConfig.copy(recordIntervalMs = finalValue)
             Service.service?.updateConfig(serverConfig)
+            refreshCombinedState()
         }
     }
 
@@ -258,6 +272,7 @@ class SettingsViewModel : ViewModel() {
             _writeLatencyMs.value = finalValue
             serverConfig = serverConfig.copy(writeLatencyMs = finalValue)
             Service.service?.updateConfig(serverConfig)
+            refreshCombinedState()
         }
     }
 
@@ -271,6 +286,7 @@ class SettingsViewModel : ViewModel() {
             _batchSize.value = finalValue
             serverConfig = serverConfig.copy(batchSize = finalValue)
             Service.service?.updateConfig(serverConfig)
+            refreshCombinedState()
         }
     }
 
@@ -280,6 +296,7 @@ class SettingsViewModel : ViewModel() {
             _screenOffRecord.value = enabled
             serverConfig = serverConfig.copy(screenOffRecordEnabled = enabled)
             Service.service?.updateConfig(serverConfig)
+            refreshCombinedState()
         }
     }
 
@@ -291,6 +308,7 @@ class SettingsViewModel : ViewModel() {
             _segmentDurationMin.value = finalValue
             serverConfig = serverConfig.copy(segmentDurationMin = finalValue)
             Service.service?.updateConfig(serverConfig)
+            refreshCombinedState()
         }
     }
 
@@ -304,6 +322,7 @@ class SettingsViewModel : ViewModel() {
             }
             _gamePackages.value = packages
             _gameBlacklist.value = newBlacklist
+            refreshCombinedState()
         }
     }
 
@@ -315,6 +334,7 @@ class SettingsViewModel : ViewModel() {
         viewModelScope.launch {
             prefs.edit { putInt(ConfigConstants.KEY_SCENE_STATS_RECENT_FILE_COUNT, finalValue) }
             _sceneStatsRecentFileCount.value = finalValue
+            refreshCombinedState()
         }
     }
 
@@ -322,6 +342,7 @@ class SettingsViewModel : ViewModel() {
         viewModelScope.launch {
             prefs.edit { putBoolean(ConfigConstants.KEY_PRED_CURRENT_SESSION_WEIGHT_ENABLED, enabled) }
             _predCurrentSessionWeightEnabled.value = enabled
+            refreshCombinedState()
         }
     }
 
@@ -333,6 +354,7 @@ class SettingsViewModel : ViewModel() {
         viewModelScope.launch {
             prefs.edit { putInt(ConfigConstants.KEY_PRED_CURRENT_SESSION_WEIGHT_MAX_X100, finalValue) }
             _predCurrentSessionWeightMaxX100.value = finalValue
+            refreshCombinedState()
         }
     }
 
@@ -344,7 +366,43 @@ class SettingsViewModel : ViewModel() {
         viewModelScope.launch {
             prefs.edit { putLong(ConfigConstants.KEY_PRED_CURRENT_SESSION_WEIGHT_HALF_LIFE_MIN, finalValue) }
             _predCurrentSessionWeightHalfLifeMin.value = finalValue
+            refreshCombinedState()
         }
+    }
+
+    private fun buildSettingsUiState(): SettingsUiState {
+        return SettingsUiState(
+            dualCellEnabled = _dualCellEnabled.value,
+            dischargeDisplayPositive = _dischargeDisplayPositive.value,
+            calibrationValue = _calibrationValue.value,
+            recordIntervalMs = _recordIntervalMs.value,
+            writeLatencyMs = _writeLatencyMs.value,
+            batchSize = _batchSize.value,
+            recordScreenOffEnabled = _screenOffRecord.value,
+            segmentDurationMin = _segmentDurationMin.value,
+            gamePackages = _gamePackages.value,
+            gameBlacklist = _gameBlacklist.value,
+            sceneStatsRecentFileCount = _sceneStatsRecentFileCount.value,
+            predCurrentSessionWeightEnabled = _predCurrentSessionWeightEnabled.value,
+            predCurrentSessionWeightMaxX100 = _predCurrentSessionWeightMaxX100.value,
+            predCurrentSessionWeightHalfLifeMin = _predCurrentSessionWeightHalfLifeMin.value
+        )
+    }
+
+    private fun buildStatisticsRequest(): StatisticsRequest {
+        return StatisticsRequest(
+            gamePackages = _gamePackages.value,
+            sceneStatsRecentFileCount = _sceneStatsRecentFileCount.value,
+            recordIntervalMs = _recordIntervalMs.value,
+            predCurrentSessionWeightEnabled = _predCurrentSessionWeightEnabled.value,
+            predCurrentSessionWeightMaxX100 = _predCurrentSessionWeightMaxX100.value,
+            predCurrentSessionWeightHalfLifeMin = _predCurrentSessionWeightHalfLifeMin.value
+        )
+    }
+
+    private fun refreshCombinedState() {
+        _settingsUiState.value = buildSettingsUiState()
+        _statisticsRequest.value = buildStatisticsRequest()
     }
 
     /**


### PR DESCRIPTION
- **数据模型**：新增 `SettingsUiState`、`SettingsActions` 和 `SettingsUiProps`，将分散的设置项及其变更回调进行结构化封装。
- **统计逻辑**：引入 `StatisticsRequest` 数据类，统一管理场景统计和预测所需的参数，简化 `MainViewModel` 和 `SceneStatsComputer` 的方法签名。
- **ViewModel 优化**：在 `SettingsViewModel` 中增加 `settingsUiState` 和 `statisticsRequest` 的 `StateFlow` 暴露，实现多字段状态的原子化更新；同步更新所有配置保存方法以维护组合状态。
- **UI 层重构**：
    - `SettingsScreen` 及其子组件（`CalibrationSection`、`ServerSection`、`PredictionSection`）改为接收统一的 `props` 对象，显著降低了参数传递的复杂性。
    - `HomeScreen` 改为通过 `statisticsRequest` 获取统计参数，并利用 `rememberUpdatedState` 优化了生命周期监听和异步刷新中的参数读取一致性。
- **逻辑清理**：移除了 `MainViewModel` 中重复的默认参数定义，改由 `StatisticsRequest` 统一维护。