### PR TITLE
feat: 新增开机自启提示 refactor: 优化 Binder 推送链路，解决屎山

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <application
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/app/src/main/java/yangfentuozi/batteryrecorder/ipc/BinderProvider.kt
+++ b/app/src/main/java/yangfentuozi/batteryrecorder/ipc/BinderProvider.kt
@@ -14,7 +14,7 @@ class BinderProvider : ContentProvider() {
 
     override fun call(method: String, arg: String?, extras: Bundle?): Bundle? {
         if (method != "setBinder" || extras == null) {
-            return Bundle().apply { putBoolean("accepted", false) }
+            return Bundle.EMPTY
         }
 
         val binder: IBinder? = extras.getBinder("binder")
@@ -22,8 +22,8 @@ class BinderProvider : ContentProvider() {
         if (binderAlive) {
             Service.binder = binder
         }
-        Log.i("BatteryRecorderApp", "[BINDER] received=${binderAlive}")
-        return Bundle().apply { putBoolean("accepted", binderAlive) }
+        Log.i("BatteryRecorderApp", "[BINDER] received=$binderAlive")
+        return Bundle.EMPTY
     }
 
     override fun query(uri: Uri, projection: Array<out String>?, selection: String?, selectionArgs: Array<out String>?, sortOrder: String?): Cursor? = null

--- a/app/src/main/java/yangfentuozi/batteryrecorder/startup/BootAutoStartNotification.kt
+++ b/app/src/main/java/yangfentuozi/batteryrecorder/startup/BootAutoStartNotification.kt
@@ -1,0 +1,94 @@
+package yangfentuozi.batteryrecorder.startup
+
+import android.Manifest
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.content.ContextCompat
+import yangfentuozi.batteryrecorder.R
+
+object BootAutoStartNotification {
+    private const val CHANNEL_ID = "boot_auto_start_reminder"
+    private const val CHANNEL_NAME = "开机自启提醒"
+    private const val CHANNEL_DESCRIPTION = "用于提示开机自启相关操作"
+    private const val NOTIFICATION_ID_PERMISSION_HINT = 10001
+    private const val NOTIFICATION_ID_BOOT_RESULT = 10002
+    const val CONTENT_TEXT = "请在系统设置中允许 BatteryRecorder 自启动"
+    private const val BOOT_SUCCESS_TITLE = "开机自启动已完成"
+    private const val BOOT_SUCCESS_TEXT = "已发起服务启动"
+    private const val BOOT_FAILED_TITLE = "开机自启动失败"
+    private const val BOOT_FAILED_TEXT = "服务启动命令执行失败"
+
+    @Suppress("DEPRECATION")
+    fun notifyEnabled(context: Context) {
+        val appContext = context.applicationContext
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val granted = ContextCompat.checkSelfPermission(
+                appContext,
+                Manifest.permission.POST_NOTIFICATIONS
+            ) == PackageManager.PERMISSION_GRANTED
+            if (!granted) return
+        }
+
+        val manager = appContext.getSystemService(NotificationManager::class.java) ?: return
+        ensureChannel(manager)
+        val notification = Notification.Builder(appContext, CHANNEL_ID)
+            .setSmallIcon(R.mipmap.ic_launcher)
+            .setContentTitle("开机自启已开启")
+            .setContentText(CONTENT_TEXT)
+            .setCategory(Notification.CATEGORY_REMINDER)
+            .setPriority(Notification.PRIORITY_HIGH)
+            .setAutoCancel(true)
+            .build()
+        runCatching {
+            manager.notify(NOTIFICATION_ID_PERMISSION_HINT, notification)
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    fun notifyBootAutoStartResult(context: Context, started: Boolean) {
+        val appContext = context.applicationContext
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val granted = ContextCompat.checkSelfPermission(
+                appContext,
+                Manifest.permission.POST_NOTIFICATIONS
+            ) == PackageManager.PERMISSION_GRANTED
+            if (!granted) return
+        }
+
+        val manager = appContext.getSystemService(NotificationManager::class.java) ?: return
+        ensureChannel(manager)
+        val (title, text) = if (started) {
+            BOOT_SUCCESS_TITLE to BOOT_SUCCESS_TEXT
+        } else {
+            BOOT_FAILED_TITLE to BOOT_FAILED_TEXT
+        }
+        val notification = Notification.Builder(appContext, CHANNEL_ID)
+            .setSmallIcon(R.mipmap.ic_launcher)
+            .setContentTitle(title)
+            .setContentText(text)
+            .setCategory(Notification.CATEGORY_STATUS)
+            .setPriority(Notification.PRIORITY_HIGH)
+            .setAutoCancel(true)
+            .build()
+        runCatching {
+            manager.notify(NOTIFICATION_ID_BOOT_RESULT, notification)
+        }
+    }
+
+    private fun ensureChannel(manager: NotificationManager) {
+        if (manager.getNotificationChannel(CHANNEL_ID) != null) return
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            CHANNEL_NAME,
+            NotificationManager.IMPORTANCE_HIGH
+        ).apply {
+            description = CHANNEL_DESCRIPTION
+            setShowBadge(true)
+        }
+        manager.createNotificationChannel(channel)
+    }
+}

--- a/app/src/main/java/yangfentuozi/batteryrecorder/startup/BootCompletedReceiver.kt
+++ b/app/src/main/java/yangfentuozi/batteryrecorder/startup/BootCompletedReceiver.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.provider.Settings
 import android.util.Log
 import yangfentuozi.batteryrecorder.shared.config.ConfigConstants
+import androidx.core.content.edit
 
 class BootCompletedReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
@@ -48,20 +49,21 @@ class BootCompletedReceiver : BroadcastReceiver() {
                             Log.i(TAG, "[BOOT] 命中 boot_count 去重，跳过自启动，boot_count=$currentBootCount")
                             return@Thread
                         }
-                        prefs.edit()
-                            .putInt(
+                        prefs.edit {
+                            putInt(
                                 ConfigConstants.KEY_ROOT_BOOT_AUTO_START_LAST_BOOT_COUNT,
                                 currentBootCount
                             )
-                            .apply()
+                        }
                         Log.i(TAG, "[BOOT] 已记录 boot_count 去重标记，boot_count=$currentBootCount")
                     }
 
                     Log.i(TAG, "[BOOT] 满足自启动条件，准备拉起服务")
-                    RootServerStarter.start(
+                    val started = RootServerStarter.start(
                         context = appContext,
                         source = RootServerStarter.Source.BOOT
                     )
+                    BootAutoStartNotification.notifyBootAutoStartResult(appContext, started)
                 } catch (e: Throwable) {
                     Log.e(TAG, "[BOOT] 开机自启动执行失败", e)
                 } finally {

--- a/app/src/main/java/yangfentuozi/batteryrecorder/ui/components/settings/sections/ServerSection.kt
+++ b/app/src/main/java/yangfentuozi/batteryrecorder/ui/components/settings/sections/ServerSection.kt
@@ -1,7 +1,12 @@
 package yangfentuozi.batteryrecorder.ui.components.settings.sections
 
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
 import android.widget.Toast
 import androidx.compose.foundation.layout.padding
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -10,6 +15,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+import yangfentuozi.batteryrecorder.startup.BootAutoStartNotification
 import yangfentuozi.batteryrecorder.ui.components.global.M3ESwitchWidget
 import yangfentuozi.batteryrecorder.ui.components.global.SplicedColumnGroup
 import yangfentuozi.batteryrecorder.ui.components.settings.SettingsItem
@@ -31,6 +38,9 @@ fun ServerSection(
     var showWriteLatencyDialog by remember { mutableStateOf(false) }
     var showBatchSizeDialog by remember { mutableStateOf(false) }
     var showSegmentDurationDialog by remember { mutableStateOf(false) }
+    val notificationPermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission()
+    ) { _ -> }
 
     SplicedColumnGroup(
         title = "服务端",
@@ -42,13 +52,21 @@ fun ServerSection(
                 checked = state.rootBootAutoStartEnabled,
                 onCheckedChange = { enabled ->
                     actions.setRootBootAutoStartEnabled(enabled)
-                    if (enabled) {
-                        Toast.makeText(
+                    if (!enabled) return@M3ESwitchWidget
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                        val granted = ContextCompat.checkSelfPermission(
                             context,
-                            "请手动在系统设置中允许自启动",
-                            Toast.LENGTH_SHORT
-                        ).show()
+                            Manifest.permission.POST_NOTIFICATIONS
+                        ) == PackageManager.PERMISSION_GRANTED
+                        if (!granted) {
+                            notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                        }
                     }
+                    Toast.makeText(
+                        context,
+                        BootAutoStartNotification.CONTENT_TEXT,
+                        Toast.LENGTH_LONG
+                    ).show()
                 }
             )
         }

--- a/server/src/main/java/yangfentuozi/batteryrecorder/server/Server.kt
+++ b/server/src/main/java/yangfentuozi/batteryrecorder/server/Server.kt
@@ -30,8 +30,6 @@ import yangfentuozi.hiddenapi.compat.PackageManagerCompat
 import yangfentuozi.hiddenapi.compat.ServiceManagerCompat
 import java.io.File
 import java.io.IOException
-import java.io.RandomAccessFile
-import java.nio.channels.FileLock
 import java.nio.file.Files
 import java.util.Scanner
 import kotlin.system.exitProcess
@@ -47,8 +45,6 @@ class Server internal constructor() : IService.Stub() {
     private lateinit var appPowerDataDir: File
     private lateinit var shellDataDir: File
     private lateinit var shellPowerDataDir: File
-    private var instanceLockFile: RandomAccessFile? = null
-    private var instanceLock: FileLock? = null
 
     private fun startService() {
         fun getAppInfo(packageName: String): ApplicationInfo {
@@ -250,10 +246,9 @@ class Server internal constructor() : IService.Stub() {
             writer.close()
         }
 
-        releaseInstanceLock()
     }
 
-    private fun sendBinder(attempt: Int): Boolean {
+    private fun sendBinder() {
         try {
             val reply = ActivityManagerCompat.contentProviderCall(
                 "yangfentuozi.batteryrecorder.binderProvider",
@@ -263,77 +258,12 @@ class Server internal constructor() : IService.Stub() {
                     putBinder("binder", this@Server)
                 }
             )
-            val accepted = reply?.getBoolean("accepted", false) == true
-            if (accepted) {
-                Log.i(TAG, "[BINDER] 推送成功 attempt=$attempt")
-            } else {
-                Log.w(TAG, "[BINDER] 推送被拒绝 attempt=$attempt")
+            if (reply == null) {
+                Log.w(TAG, "[BINDER] provider==null，跳过推送")
             }
-            return accepted
         } catch (e: RemoteException) {
-            Log.e(TAG, "[BINDER] 推送失败 attempt=$attempt", e)
+            Log.e(TAG, "[BINDER] 推送失败", e)
         }
-        return false
-    }
-
-    private fun scheduleSendBinderRetry() {
-        mMainHandler.postDelayed(
-            {
-                sendBinder(2)
-            },
-            BINDER_RETRY_DELAY_MS
-        )
-    }
-
-    private fun sendBinder() {
-        if (!sendBinder(1)) {
-            scheduleSendBinderRetry()
-        }
-    }
-
-    private fun acquireInstanceLockOrExit() {
-        try {
-            val lockFile = File(SINGLETON_LOCK_FILE_PATH)
-            lockFile.parentFile?.mkdirs()
-            if (!lockFile.exists()) {
-                lockFile.createNewFile()
-            }
-            ensureLockFileWritable(lockFile)
-            val randomAccessFile = RandomAccessFile(lockFile, "rw")
-            ensureLockFileWritable(lockFile)
-            val lock = randomAccessFile.channel.tryLock()
-            if (lock == null) {
-                randomAccessFile.close()
-                Log.e(TAG, "[SINGLETON] 已有服务实例运行，当前进程退出")
-                exitProcess(0)
-            }
-
-            randomAccessFile.setLength(0)
-            randomAccessFile.writeBytes("${Os.getpid()}\n")
-            instanceLockFile = randomAccessFile
-            instanceLock = lock
-            Log.i(TAG, "[SINGLETON] 获取实例锁成功 pid=${Os.getpid()}")
-        } catch (e: Throwable) {
-            Log.e(TAG, "[SINGLETON] 获取实例锁失败，当前进程退出", e)
-            exitProcess(1)
-        }
-    }
-
-    private fun ensureLockFileWritable(lockFile: File) {
-        runCatching {
-            Os.chmod(lockFile.absolutePath, SINGLETON_LOCK_FILE_MODE)
-        }.onFailure {
-            Log.w(TAG, "[SINGLETON] 设置锁文件权限失败 path=${lockFile.absolutePath}", it)
-        }
-    }
-
-    private fun releaseInstanceLock() {
-        runCatching { instanceLock?.release() }
-            .onFailure { Log.w(TAG, "[SINGLETON] 释放实例锁失败", it) }
-        runCatching { instanceLockFile?.close() }
-            .onFailure { Log.w(TAG, "[SINGLETON] 关闭锁文件失败", it) }
-        instanceLock = null
-        instanceLockFile = null
     }
 
     init {
@@ -342,7 +272,6 @@ class Server internal constructor() : IService.Stub() {
         }
 
         mMainHandler = Handler(Looper.getMainLooper())
-        acquireInstanceLockOrExit()
         Runtime.getRuntime().addShutdownHook(Thread { this.stopServiceImmediately() })
         ServiceManagerCompat.waitService("activity_task")
         ServiceManagerCompat.waitService("display")
@@ -354,9 +283,6 @@ class Server internal constructor() : IService.Stub() {
 
     companion object {
         const val TAG: String = "Server"
-        private const val BINDER_RETRY_DELAY_MS = 300L
-        private const val SINGLETON_LOCK_FILE_PATH = "/data/local/tmp/batteryrecorder_server.lock"
-        private val SINGLETON_LOCK_FILE_MODE = "666".toInt(8)
 
         var appUid: Int = 0
 


### PR DESCRIPTION
- 新增开机自启通知工具，区分权限提示与开机自启动结果提示
- 设置页开启开机自启时补充通知权限申请与 Toast 提示
- BootCompletedReceiver 在启动后上报通知
- BinderProvider 不再返回 accepted，Server 侧移除 accepted/retry 分支
- Server 移除单例锁相关实现