### PR TITLE
fix: 尝试修复部分设备偶发当前记录获取失败

### DIFF
--- a/app/src/main/java/yangfentuozi/batteryrecorder/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/yangfentuozi/batteryrecorder/ui/screens/home/HomeScreen.kt
@@ -83,6 +83,7 @@ fun HomeScreen(
     val latestSettingsInitialized by rememberUpdatedState(settingsInitialized)
     val latestStatisticsRequest by rememberUpdatedState(statisticsRequest)
     var prevServiceConnected by remember { mutableStateOf(false) }
+    var isRecordListenerRegistered by remember { mutableStateOf(false) }
     val dualCellEnabled = settingsState.dualCellEnabled
     val calibrationValue = settingsState.calibrationValue
     val dischargeDisplayPositive = settingsState.dischargeDisplayPositive
@@ -128,16 +129,32 @@ fun HomeScreen(
         }
     }
 
+    fun registerRecordListenerIfNeeded() {
+        if (isRecordListenerRegistered) return
+        val service = Service.service ?: return
+        service.registerRecordListener(listener)
+        isRecordListenerRegistered = true
+    }
+
+    fun unregisterRecordListenerIfNeeded() {
+        if (!isRecordListenerRegistered) return
+        Service.service?.unregisterRecordListener(listener)
+        isRecordListenerRegistered = false
+    }
+
     LaunchedEffect(serviceConnected, settingsInitialized) {
         if (!settingsInitialized) return@LaunchedEffect
         val shouldDoDelayedRefresh = serviceConnected && !prevServiceConnected
         prevServiceConnected = serviceConnected
+        if (!serviceConnected) {
+            isRecordListenerRegistered = false
+        }
         if (!shouldDoDelayedRefresh) return@LaunchedEffect
         if (!lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
             return@LaunchedEffect
         }
 
-        Service.service?.registerRecordListener(listener)
+        registerRecordListenerIfNeeded()
         run {
             delay(1500)
             viewModel.refreshStatisticsTrackingCurrentRecord(
@@ -152,6 +169,7 @@ fun HomeScreen(
         if (!lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
             return@LaunchedEffect
         }
+        registerRecordListenerIfNeeded()
         // 首次设置初始化完成时补一次前台刷新；后续页面恢复依赖 ON_START，
         // 避免返回首页时走 ClearAndReload 先清空卡片与统计。
         viewModel.refreshStatisticsTrackingCurrentRecord(
@@ -171,17 +189,18 @@ fun HomeScreen(
         val observer = LifecycleEventObserver { _, event ->
             when (event) {
                 Lifecycle.Event.ON_START -> {
+                    // 先恢复监听，再拉取当前记录，尽量缩短前台恢复时的空窗口。
+                    registerRecordListenerIfNeeded()
                     if (latestSettingsInitialized) {
                         viewModel.refreshStatisticsTrackingCurrentRecord(
                             context = context,
                             request = latestStatisticsRequest
                         )
                     }
-                    Service.service?.registerRecordListener(listener)
                 }
 
                 Lifecycle.Event.ON_STOP -> {
-                    Service.service?.unregisterRecordListener(listener)
+                    unregisterRecordListenerIfNeeded()
                 }
 
                 else -> {}
@@ -190,6 +209,7 @@ fun HomeScreen(
         lifecycleOwner.lifecycle.addObserver(observer)
 
         onDispose {
+            unregisterRecordListenerIfNeeded()
             lifecycleOwner.lifecycle.removeObserver(observer)
         }
     }

--- a/app/src/main/java/yangfentuozi/batteryrecorder/ui/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/yangfentuozi/batteryrecorder/ui/viewmodel/MainViewModel.kt
@@ -89,6 +89,7 @@ class MainViewModel : ViewModel() {
     private var statisticsJob: Job? = null
     private var statisticsGeneration: Long = 0L
     private var pendingCurrentRecordsFile: RecordsFile? = null
+    private var isPreservingCurrentRecordUiState: Boolean = false
     private val liveSegmentBuffer = LiveSegmentBuffer()
 
     private val serviceListener = object : Service.ServiceConnection {
@@ -319,6 +320,7 @@ class MainViewModel : ViewModel() {
             if (liveSegmentBuffer.recordsFileName == recordsFile.name) {
                 return@runOnMainThread
             }
+            isPreservingCurrentRecordUiState = false
             pendingCurrentRecordsFile = recordsFile
             switchActiveLiveSegment(recordsFile.name)
             _currentRecordUiState.value =
@@ -353,6 +355,25 @@ class MainViewModel : ViewModel() {
     ) {
         runOnMainThread {
             val pendingFile = pendingCurrentRecordsFile
+            if (isPreservingCurrentRecordUiState) {
+                if (!_isLoadingStats.value) {
+                    if (pendingFile != null) {
+                        LoggerX.v<MainViewModel>("[首页] 当前记录处于保留态，收到新采样后重试分段: ${pendingFile.name}")
+                        refreshStatisticsTrackingCurrentRecord(
+                            context = context.applicationContext,
+                            request = request,
+                            expectedCurrentRecordsFile = pendingFile
+                        )
+                    } else {
+                        LoggerX.v<MainViewModel>("[首页] 当前记录文件暂不可用，收到新采样后重试拉取当前记录")
+                        refreshStatisticsTrackingCurrentRecord(
+                            context = context.applicationContext,
+                            request = request
+                        )
+                    }
+                }
+                return@runOnMainThread
+            }
             if (pendingFile != null && liveSegmentBuffer.recordsFileName != pendingFile.name) {
                 switchActiveLiveSegment(pendingFile.name)
             }
@@ -418,6 +439,7 @@ class MainViewModel : ViewModel() {
 
     private fun clearDisplayedHomeState() {
         pendingCurrentRecordsFile = null
+        isPreservingCurrentRecordUiState = false
         liveSegmentBuffer.recordsFileName = null
         liveSegmentBuffer.points.clear()
         _chargeSummary.value = null
@@ -438,6 +460,33 @@ class MainViewModel : ViewModel() {
     ): String {
         val detail = error.message?.takeIf { it.isNotBlank() } ?: error::class.java.simpleName
         return "当前记录加载失败：${recordsFile.name}（$detail）"
+    }
+
+    /**
+     * 在跟踪当前记录刷新时，判断是否需要保留上一次有效展示。
+     *
+     * 仅针对 Binder 或当前记录文件临时不可用场景保留旧值，避免首页恢复时被瞬时空结果覆盖。
+     *
+     * @param mode 当前刷新模式。
+     * @param currentUiState 当前首页展示状态。
+     * @param targetRecordsFile 本次尝试加载的目标记录文件。
+     * @param currentRecordResult 本次当前记录加载结果。
+     * @return 需要保留旧展示时返回原因，否则返回 null。
+     */
+    private fun resolveCurrentRecordPreserveReason(
+        mode: StatisticsRefreshMode,
+        currentUiState: CurrentRecordUiState,
+        targetRecordsFile: RecordsFile?,
+        currentRecordResult: CurrentRecordDisplayLoadResult?
+    ): String? {
+        if (mode != StatisticsRefreshMode.TrackCurrentRecord || currentUiState.record == null) {
+            return null
+        }
+        return when {
+            targetRecordsFile == null -> "当前记录文件暂不可用"
+            currentRecordResult is CurrentRecordDisplayLoadResult.Missing -> "当前记录文件暂未同步到本地"
+            else -> null
+        }
     }
 
     private fun startLoadStatistics(
@@ -565,24 +614,41 @@ class MainViewModel : ViewModel() {
                 if (generation == statisticsGeneration) {
                     _chargeSummary.value = chargeSummary
                     _dischargeSummary.value = dischargeSummary
-                    pendingCurrentRecordsFile = nextPendingRecordsFile
-                    switchActiveLiveSegment(nextActiveLiveRecordsFileName)
-                    val currentUiState = _currentRecordUiState.value
-
-                    val nextDisplayStatus = when {
-                        nextPendingRecordsFile != null -> nextPendingRecordsFile.type
-                        resolvedCurrentRecord != null -> resolvedCurrentRecord.type
-                        serviceCurrentRecordsFile != null -> serviceCurrentRecordsFile.type
-                        else -> currentUiState.displayStatus
-                    }
-                    _currentRecordUiState.value =
-                        currentUiState.copy(
-                            recordsFileName = liveSegmentBuffer.recordsFileName,
-                            displayStatus = nextDisplayStatus,
-                            isSwitching = nextPendingRecordsFile != null,
-                            record = resolvedCurrentRecord,
-                            livePoints = snapshotLivePoints()
+                    val previousCurrentUiState = _currentRecordUiState.value
+                    val preserveCurrentRecordReason = resolveCurrentRecordPreserveReason(
+                        mode = mode,
+                        currentUiState = previousCurrentUiState,
+                        targetRecordsFile = targetRecordsFile,
+                        currentRecordResult = currentRecordResult
+                    )
+                    if (preserveCurrentRecordReason != null) {
+                        isPreservingCurrentRecordUiState = true
+                        pendingCurrentRecordsFile = nextPendingRecordsFile
+                        LoggerX.w<MainViewModel>(
+                            "[首页] $preserveCurrentRecordReason，保留上次有效当前记录: ${previousCurrentUiState.record?.name}"
                         )
+                        _currentRecordUiState.value = previousCurrentUiState
+                    } else {
+                        isPreservingCurrentRecordUiState = false
+                        pendingCurrentRecordsFile = nextPendingRecordsFile
+                        switchActiveLiveSegment(nextActiveLiveRecordsFileName)
+                        val currentUiState = _currentRecordUiState.value
+                        val resolvedDisplayStatus = when {
+                            nextPendingRecordsFile != null -> nextPendingRecordsFile.type
+                            resolvedCurrentRecord != null -> resolvedCurrentRecord.type
+                            serviceCurrentRecordsFile != null -> serviceCurrentRecordsFile.type
+                            else -> currentUiState.displayStatus
+                        }
+                        _currentRecordUiState.value =
+                            currentUiState.copy(
+                                recordsFileName = liveSegmentBuffer.recordsFileName,
+                                displayStatus = resolvedDisplayStatus,
+                                isSwitching = nextPendingRecordsFile != null,
+                                record = resolvedCurrentRecord,
+                                livePoints = snapshotLivePoints(),
+                                lastTemp = currentUiState.lastTemp
+                            )
+                    }
 
                     _sceneStats.value = stats?.displayStats
                     if (shouldRefreshPrediction) {


### PR DESCRIPTION
- **状态管理**：
    - **UI 状态保留**：在 `MainViewModel` 中引入 `isPreservingCurrentRecordUiState` 机制。当 Binder 服务连接异常或记录文件尚未同步到本地时，保留上一次有效的 UI 展示，避免首页因瞬时空数据产生闪烁。
    - **逻辑重构**：新增 `resolveCurrentRecordPreserveReason` 方法，统一判定是否需要挂起 UI 更新；在 `onLiveSampleReceived` 中增加补偿逻辑，确保在保留态下收到新采样点时能及时触发重试。
- **性能与稳定性**：
    - **监听器生命周期优化**：在 `HomeScreen` 中封装 `registerRecordListenerIfNeeded` 与 `unregisterRecordListenerIfNeeded`，引入 `isRecordListenerRegistered` 标记，确保监听器在 `ON_START`、`Service` 连接及设置初始化等场景下被幂等且正确地注册与反注册。
    - **时序优化**：调整生命周期回调顺序，确保在前台恢复时先恢复数据监听再拉取历史记录，最大限度缩短数据更新的空白窗口。
- **数据同步**：
    - 修复了在更新 `CurrentRecordUiState` 时可能丢失 `lastTemp`（最后一次温度数据）的问题。