### PR TITLE
fix(server): 修复 shell 通知FakeContext provider 获取方式

### DIFF
--- a/server/src/main/java/yangfentuozi/batteryrecorder/server/fakecontext/ExternalProviderResolver.java
+++ b/server/src/main/java/yangfentuozi/batteryrecorder/server/fakecontext/ExternalProviderResolver.java
@@ -1,0 +1,108 @@
+package yangfentuozi.batteryrecorder.server.fakecontext;
+
+import android.app.ContentProviderHolder;
+import android.app.IActivityManager;
+import android.content.ContentResolver;
+import android.content.Context;
+import android.content.IContentProvider;
+import android.os.IBinder;
+import android.os.RemoteException;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+final class ExternalProviderResolver extends ContentResolver {
+
+    private final IActivityManager activityManager;
+    private final IBinder providerToken;
+    private final ConcurrentHashMap<IBinder, ProviderRef> providerRefs =
+            new ConcurrentHashMap<>();
+
+    ExternalProviderResolver(Context context,
+                             IActivityManager activityManager,
+                             IBinder providerToken) {
+        super(context);
+        this.activityManager = activityManager;
+        this.providerToken = providerToken;
+    }
+
+    @SuppressWarnings({"unused", "ProtectedMemberInFinalClass"})
+    protected IContentProvider acquireProvider(Context context, String auth) {
+        return acquireExternalProvider(auth);
+    }
+
+    @SuppressWarnings({"unused", "ProtectedMemberInFinalClass"})
+    protected IContentProvider acquireExistingProvider(Context context, String auth) {
+        return acquireExternalProvider(auth);
+    }
+
+    @SuppressWarnings("unused")
+    public boolean releaseProvider(IContentProvider provider) {
+        return releaseExternalProvider(provider);
+    }
+
+    @SuppressWarnings({"unused", "ProtectedMemberInFinalClass"})
+    protected IContentProvider acquireUnstableProvider(Context context, String auth) {
+        return acquireExternalProvider(auth);
+    }
+
+    @SuppressWarnings("unused")
+    public boolean releaseUnstableProvider(IContentProvider provider) {
+        return releaseExternalProvider(provider);
+    }
+
+    @SuppressWarnings("unused")
+    public void unstableProviderDied(IContentProvider provider) {
+    }
+
+    @SuppressWarnings("unused")
+    public void appNotRespondingViaProvider(IContentProvider provider) {
+    }
+
+    private IContentProvider acquireExternalProvider(String auth) {
+        try {
+            ContentProviderHolder holder =
+                    activityManager.getContentProviderExternal(auth, 0, providerToken, auth);
+            if (holder == null || holder.provider == null) {
+                return null;
+            }
+            IContentProvider provider = holder.provider;
+            providerRefs.compute(provider.asBinder(), (binder, ref) -> {
+                if (ref != null) {
+                    ref.count.incrementAndGet();
+                    return ref;
+                }
+                return new ProviderRef(auth);
+            });
+            return provider;
+        } catch (RemoteException e) {
+            throw e.rethrowFromSystemServer();
+        }
+    }
+
+    private boolean releaseExternalProvider(IContentProvider provider) {
+        ProviderRef ref = providerRefs.get(provider.asBinder());
+        if (ref == null) {
+            return false;
+        }
+        if (ref.count.decrementAndGet() > 0) {
+            return true;
+        }
+        providerRefs.remove(provider.asBinder(), ref);
+        try {
+            activityManager.removeContentProviderExternal(ref.authority, providerToken);
+            return true;
+        } catch (RemoteException e) {
+            throw e.rethrowFromSystemServer();
+        }
+    }
+
+    private static final class ProviderRef {
+        private final String authority;
+        private final AtomicInteger count = new AtomicInteger(1);
+
+        private ProviderRef(String authority) {
+            this.authority = authority;
+        }
+    }
+}

--- a/server/src/main/java/yangfentuozi/batteryrecorder/server/fakecontext/FakeContext.kt
+++ b/server/src/main/java/yangfentuozi/batteryrecorder/server/fakecontext/FakeContext.kt
@@ -1,18 +1,21 @@
 package yangfentuozi.batteryrecorder.server.fakecontext
 
 import android.annotation.SuppressLint
+import android.app.IActivityManager
 import android.content.AttributionSource
+import android.content.ContentResolver
 import android.content.Context
 import android.content.ContextWrapper
 import android.content.pm.ApplicationInfo
+import android.os.Binder
+import android.os.ServiceManager
 import android.system.Os
-import android.util.Log
 import androidx.annotation.Keep
-import java.lang.reflect.Constructor
+import java.lang.reflect.Method
 
 @Keep
 class FakeContext : ContextWrapper(systemContext) {
-    private val packageContext: Context = systemContext ?: this
+    private val packageContext: Context = systemContext
 
     override fun getPackageName(): String {
         return PACKAGE_NAME
@@ -51,44 +54,41 @@ class FakeContext : ContextWrapper(systemContext) {
         return packageContext
     }
 
+    override fun getContentResolver(): ContentResolver {
+        return externalContentResolver
+    }
+
     @SuppressLint("DiscouragedPrivateApi")
     companion object {
         var PACKAGE_NAME: String = if (Os.getuid() == 0) "root" else "com.android.shell"
 
-        private var ACTIVITY_THREAD_CLASS: Class<*>? = null
-        private var ACTIVITY_THREAD: Any? = null
+        private val providerToken = Binder()
 
-        init {
-            try {
-                ACTIVITY_THREAD_CLASS = Class.forName("android.app.ActivityThread")
-                val activityThreadConstructor: Constructor<*>? =
-                    ACTIVITY_THREAD_CLASS?.getDeclaredConstructor()
-                activityThreadConstructor?.isAccessible = true
-                ACTIVITY_THREAD = activityThreadConstructor?.newInstance()
-
-                val sCurrentActivityThreadField =
-                    ACTIVITY_THREAD_CLASS?.getDeclaredField("sCurrentActivityThread")
-                sCurrentActivityThreadField?.isAccessible = true
-                sCurrentActivityThreadField?.set(null, ACTIVITY_THREAD)
-            } catch (e: Exception) {
-                throw AssertionError(e)
-            }
+        private val activityManager: IActivityManager by lazy(LazyThreadSafetyMode.SYNCHRONIZED) {
+            IActivityManager.Stub.asInterface(ServiceManager.getService("activity"))
+                ?: throw IllegalStateException("activity 服务未就绪")
         }
 
-        val systemContext: Context?
-            get() {
-                try {
-                    val getSystemContextMethod =
-                        ACTIVITY_THREAD_CLASS!!.getDeclaredMethod("getSystemContext")
-                    return getSystemContextMethod.invoke(ACTIVITY_THREAD) as Context?
-                } catch (throwable: Throwable) {
-                    Log.e(
-                        "FakeContext",
-                        "Workarounds: Failed to get system context: ${throwable.stackTraceToString()}",
-                        throwable
-                    )
-                    return null
-                }
+        private val activityThreadClass: Class<*> = Class.forName("android.app.ActivityThread")
+        private val currentActivityThreadMethod: Method =
+            activityThreadClass.getDeclaredMethod("currentActivityThread").apply {
+                isAccessible = true
             }
+        private val systemMainMethod: Method =
+            activityThreadClass.getDeclaredMethod("systemMain").apply { isAccessible = true }
+        private val getSystemContextMethod: Method =
+            activityThreadClass.getDeclaredMethod("getSystemContext").apply { isAccessible = true }
+
+        val systemContext: Context by lazy(LazyThreadSafetyMode.SYNCHRONIZED) {
+            val activityThread = currentActivityThreadMethod.invoke(null)
+                ?: systemMainMethod.invoke(null)
+                ?: throw IllegalStateException("获取 system ActivityThread 失败")
+            getSystemContextMethod.invoke(activityThread) as? Context
+                ?: throw IllegalStateException("获取 systemContext 失败")
+        }
+
+        private val externalContentResolver by lazy(LazyThreadSafetyMode.SYNCHRONIZED) {
+            ExternalProviderResolver(systemContext, activityManager, providerToken)
+        }
     }
 }


### PR DESCRIPTION
## 变更说明
- 调整 shell 通知 FakeContext 的 provider 获取方式
- 通过 external provider resolver 访问 provider，避免 Android 16 上 Notification.Builder 内部读取 Settings 时走默认 provider 链路
- 保持 Notification.Builder 与现有 shell 通知主链不变

## 影响范围
- server/src/main/java/yangfentuozi/batteryrecorder/server/fakecontext/FakeContext.kt
- server/src/main/java/yangfentuozi/batteryrecorder/server/fakecontext/ExternalProviderResolver.java