### PR TITLE
fix: 尝试修复低性能设备启动无法正确获取回调

### DIFF
--- a/app/src/main/java/yangfentuozi/batteryrecorder/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/yangfentuozi/batteryrecorder/ui/screens/home/HomeScreen.kt
@@ -42,7 +42,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.viewmodel.compose.viewModel
-import kotlinx.coroutines.delay
 import yangfentuozi.batteryrecorder.R
 import yangfentuozi.batteryrecorder.ipc.Service
 import yangfentuozi.batteryrecorder.server.recorder.IRecordListener
@@ -208,22 +207,19 @@ fun HomeScreen(
 
     LaunchedEffect(serviceConnected, settingsInitialized) {
         if (!settingsInitialized) return@LaunchedEffect
-        val shouldDoDelayedRefresh = serviceConnected && !prevServiceConnected
+        val shouldRefreshOnReconnect = serviceConnected && !prevServiceConnected
         prevServiceConnected = serviceConnected
-        if (!shouldDoDelayedRefresh) return@LaunchedEffect
+        if (!shouldRefreshOnReconnect) return@LaunchedEffect
         if (!lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
             return@LaunchedEffect
         }
 
         Service.service?.registerRecordListener(listener)
-        run {
-            delay(1500)
-            viewModel.refreshStatisticsTrackingCurrentRecord(
-                context = context,
-                request = statisticsSettings,
-                recordIntervalMs = recordIntervalMs
-            )
-        }
+        viewModel.refreshStatisticsTrackingCurrentRecord(
+            context = context,
+            request = statisticsSettings,
+            recordIntervalMs = recordIntervalMs
+        )
     }
 
     LaunchedEffect(settingsInitialized) {

--- a/server/src/main/java/yangfentuozi/batteryrecorder/server/Server.kt
+++ b/server/src/main/java/yangfentuozi/batteryrecorder/server/Server.kt
@@ -160,7 +160,7 @@ class Server internal constructor() : IService.Stub() {
     }
 
     override fun sync(): ParcelFileDescriptor? {
-        writer.flushBuffer()
+        writer.flushBufferBlocking()
         if (Os.getuid() == 0) {
             LoggerX.d(TAG, "sync: root 模式不需要同步文件, return null")
             return null

--- a/server/src/main/java/yangfentuozi/batteryrecorder/server/writer/PowerRecordWriter.kt
+++ b/server/src/main/java/yangfentuozi/batteryrecorder/server/writer/PowerRecordWriter.kt
@@ -105,6 +105,11 @@ class PowerRecordWriter(
         dischargeDataWriter.flushBuffer()
     }
 
+    fun flushBufferBlocking() {
+        chargeDataWriter.flushBufferBlocking()
+        dischargeDataWriter.flushBufferBlocking()
+    }
+
     inner class ChargeDataWriter(dir: File) : BaseDelayedRecordWriter(dir) {
         override fun needStartNewSegment(justChangedStatus: Boolean, nowTime: Long): Boolean {
             // case1 记录超过最大分段时间（0 表示不按时间分段）
@@ -165,7 +170,7 @@ class PowerRecordWriter(
 
             if (startedNewSegment) {
                 LoggerX.d(BASE_TAG, "write: 新分段已创建, 立即落盘, file=${segmentFile?.name}")
-                writer!!.flushNow()
+                writer!!.flushNowBlocking()
                 val currentFile = segmentFile
                 if (currentFile != null) {
                     LoggerX.d(
@@ -185,7 +190,7 @@ class PowerRecordWriter(
 
             writer!!.onEnqueued()
             if (justChangedStatus) {
-                writer!!.flushNow()
+                writer!!.flushNowBlocking()
                 val currentFile = segmentFile
                 if (currentFile != null) {
                     LoggerX.d(
@@ -256,6 +261,10 @@ class PowerRecordWriter(
 
         fun flushBuffer() {
             writer?.flushNow()
+        }
+
+        fun flushBufferBlocking() {
+            writer?.flushNowBlocking()
         }
 
         fun closeCurrentSegment() {

--- a/shared/src/main/java/yangfentuozi/batteryrecorder/shared/writer/AdvancedWriter.kt
+++ b/shared/src/main/java/yangfentuozi/batteryrecorder/shared/writer/AdvancedWriter.kt
@@ -61,6 +61,14 @@ class AdvancedWriter(
         flushInternal("flushNow")
     }
 
+    /**
+     * 立即把当前缓冲与后台重试缓冲都刷到输出流，并阻塞直到本轮写入完成。
+     */
+    fun flushNowBlocking() {
+        flushInternal("flushNowBlocking")
+        autoRetryWriter.drainBufferBlocking()
+    }
+
     fun close() {
         // 关闭前先取消延迟 flush，避免 close 后仍有回调触发写入
         handler.removeCallbacks(flushRunnable)
@@ -193,57 +201,62 @@ class AdvancedWriter(
             }
         }
 
-        private fun drainBufferBlocking() {
+        fun drainBufferBlocking() {
             synchronized(bufferLock) {
                 if (buffer.isEmpty()) return
+                val originalRetryIntervalMs = retryIntervalMs
                 retryIntervalMs = 100
-                var localRetryCount = 0
-                while (buffer.isNotEmpty()) {
-                    try {
-                        outputStream.write(buffer.toString().toByteArray())
-                        outputStream.flush()
-                        buffer.setLength(0)
-                        retryCount = -1
-                        return
-                    } catch (e: IOException) {
-                        if (++localRetryCount > retryTimes) {
-                            try {
-                                outputStream.close()
-                            } catch (closeErr: IOException) {
-                                LoggerX.e(
+                try {
+                    var localRetryCount = 0
+                    while (buffer.isNotEmpty()) {
+                        try {
+                            outputStream.write(buffer.toString().toByteArray())
+                            outputStream.flush()
+                            buffer.setLength(0)
+                            retryCount = -1
+                            return
+                        } catch (e: IOException) {
+                            if (++localRetryCount > retryTimes) {
+                                try {
+                                    outputStream.close()
+                                } catch (closeErr: IOException) {
+                                    LoggerX.e(
+                                        RETRY_TAG,
+                                        "drainBufferBlocking: 关闭 OutputStream 失败",
+                                        tr = closeErr,
+                                        notWrite = useAndroidLog
+                                    )
+                                }
+                                outputStream = try {
+                                    reopenOutputStream()
+                                } catch (reopenErr: IOException) {
+                                    LoggerX.e(
+                                        RETRY_TAG,
+                                        "drainBufferBlocking: 重新打开 OutputStream 失败, 多次重试失败, 强行终止",
+                                        tr = reopenErr,
+                                        notWrite = useAndroidLog
+                                    )
+                                    throw RuntimeException()
+                                }
+                                LoggerX.i(
                                     RETRY_TAG,
-                                    "drainBufferBlocking: 关闭 OutputStream 失败",
-                                    tr = closeErr,
+                                    "drainBufferBlocking: OutputStream 已重建, 继续写入重试",
                                     notWrite = useAndroidLog
                                 )
+                                localRetryCount = 0
+                                continue
                             }
-                            outputStream = try {
-                                reopenOutputStream()
-                            } catch (reopenErr: IOException) {
-                                LoggerX.e(
-                                    RETRY_TAG,
-                                    "drainBufferBlocking: 重新打开 OutputStream 失败, 多次重试失败, 强行终止",
-                                    tr = reopenErr,
-                                    notWrite = useAndroidLog
-                                )
-                                throw RuntimeException()
-                            }
-                            LoggerX.i(
+                            LoggerX.w(
                                 RETRY_TAG,
-                                "drainBufferBlocking: OutputStream 已重建, 继续写入重试",
+                                "drainBufferBlocking: 写入 OutputStream 失败, 准备重试: retryCount=$localRetryCount/$retryTimes",
+                                tr = e,
                                 notWrite = useAndroidLog
                             )
-                            localRetryCount = 0
-                            continue
+                            Thread.sleep(retryIntervalMs)
                         }
-                        LoggerX.w(
-                            RETRY_TAG,
-                            "drainBufferBlocking: 写入 OutputStream 失败, 准备重试: retryCount=$localRetryCount/$retryTimes",
-                            tr = e,
-                            notWrite = useAndroidLog
-                        )
-                        Thread.sleep(retryIntervalMs)
                     }
+                } finally {
+                    retryIntervalMs = originalRetryIntervalMs
                 }
             }
         }


### PR DESCRIPTION
- 在 `AdvancedWriter` 中新增 `flushNowBlocking` 方法，支持同步阻塞式将缓存刷入输出流。
- 优化 `AutoRetryWriter` 的 `drainBufferBlocking` 逻辑，确保重试间隔在操作完成后恢复，并公开访问权限。
- `PowerRecordWriter` 及其子类新增 `flushBufferBlocking` 接口，并在创建新分段或状态变更时改用阻塞式刷新以增强数据一致性。
- 移除 `HomeScreen` 中服务重连时的延迟等待逻辑，改为立即刷新统计数据。