### PR TITLE
improve: 将 TaskInfo 窗口边界获取从反射改为 hidden API，优化性能并调整日志输出

### DIFF
--- a/hiddenapi/compat/src/main/java/yangfentuozi/hiddenapi/compat/TaskInfoCompat.java
+++ b/hiddenapi/compat/src/main/java/yangfentuozi/hiddenapi/compat/TaskInfoCompat.java
@@ -1,0 +1,230 @@
+package yangfentuozi.hiddenapi.compat;
+
+import android.app.TaskInfo;
+import android.graphics.Rect;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+public final class TaskInfoCompat {
+    private static final String TAG = "TaskInfoCompat";
+
+    @Nullable
+    private static volatile Accessor accessor;
+
+    private static final class Accessor {
+        @Nullable
+        final Method taskInfoGetConfigurationMethod;
+        @Nullable
+        final Field taskInfoConfigurationField;
+        @Nullable
+        final Field configurationWindowConfigurationField;
+        @Nullable
+        final Method windowConfigurationGetBoundsMethod;
+        @Nullable
+        final Field windowConfigurationBoundsField;
+        @Nullable
+        final Method windowConfigurationGetMaxBoundsMethod;
+        @Nullable
+        final Field windowConfigurationMaxBoundsField;
+
+        private Accessor(
+                @Nullable Method taskInfoGetConfigurationMethod,
+                @Nullable Field taskInfoConfigurationField,
+                @Nullable Field configurationWindowConfigurationField,
+                @Nullable Method windowConfigurationGetBoundsMethod,
+                @Nullable Field windowConfigurationBoundsField,
+                @Nullable Method windowConfigurationGetMaxBoundsMethod,
+                @Nullable Field windowConfigurationMaxBoundsField
+        ) {
+            this.taskInfoGetConfigurationMethod = taskInfoGetConfigurationMethod;
+            this.taskInfoConfigurationField = taskInfoConfigurationField;
+            this.configurationWindowConfigurationField = configurationWindowConfigurationField;
+            this.windowConfigurationGetBoundsMethod = windowConfigurationGetBoundsMethod;
+            this.windowConfigurationBoundsField = windowConfigurationBoundsField;
+            this.windowConfigurationGetMaxBoundsMethod = windowConfigurationGetMaxBoundsMethod;
+            this.windowConfigurationMaxBoundsField = windowConfigurationMaxBoundsField;
+        }
+    }
+
+    private TaskInfoCompat() {
+    }
+
+    /**
+     * 读取任务当前窗口边界；任务为空时返回空。
+     *
+     * @param taskInfo 任务信息。
+     * @return 成功返回窗口当前边界，任务为空时返回 `null`。
+     */
+    @Nullable
+    public static Rect getBoundsOrNull(@Nullable TaskInfo taskInfo) {
+        if (taskInfo == null) {
+            return null;
+        }
+        final Accessor currentAccessor = getAccessor();
+        final Object windowConfiguration = readWindowConfiguration(taskInfo, currentAccessor);
+        if (windowConfiguration == null) {
+            return null;
+        }
+        return readRect(
+                windowConfiguration,
+                currentAccessor.windowConfigurationGetBoundsMethod,
+                currentAccessor.windowConfigurationBoundsField
+        );
+    }
+
+    /**
+     * 读取任务可达到的最大窗口边界；任务为空时返回空。
+     *
+     * @param taskInfo 任务信息。
+     * @return 成功返回窗口最大边界，任务为空时返回 `null`。
+     */
+    @Nullable
+    public static Rect getMaxBoundsOrNull(@Nullable TaskInfo taskInfo) {
+        if (taskInfo == null) {
+            return null;
+        }
+        final Accessor currentAccessor = getAccessor();
+        final Object windowConfiguration = readWindowConfiguration(taskInfo, currentAccessor);
+        if (windowConfiguration == null) {
+            return null;
+        }
+        return readRect(
+                windowConfiguration,
+                currentAccessor.windowConfigurationGetMaxBoundsMethod,
+                currentAccessor.windowConfigurationMaxBoundsField
+        );
+    }
+
+    @NonNull
+    private static Accessor getAccessor() {
+        final Accessor cached = accessor;
+        if (cached != null) {
+            return cached;
+        }
+        final Accessor created = new Accessor(
+                findMethod(TaskInfo.class, "getConfiguration"),
+                findField(TaskInfo.class, "configuration"),
+                findField("android.content.res.Configuration", "windowConfiguration"),
+                findMethod("android.app.WindowConfiguration", "getBounds"),
+                findField("android.app.WindowConfiguration", "bounds"),
+                findMethod("android.app.WindowConfiguration", "getMaxBounds"),
+                findField("android.app.WindowConfiguration", "maxBounds")
+        );
+        accessor = created;
+        return created;
+    }
+
+    @Nullable
+    private static Object readWindowConfiguration(
+            @NonNull TaskInfo taskInfo,
+            @NonNull Accessor accessor
+    ) {
+        final Object configuration = readObject(
+                taskInfo,
+                accessor.taskInfoGetConfigurationMethod,
+                accessor.taskInfoConfigurationField
+        );
+        if (configuration == null || accessor.configurationWindowConfigurationField == null) {
+            return null;
+        }
+        return readFieldValue(configuration, accessor.configurationWindowConfigurationField);
+    }
+
+    @Nullable
+    private static Rect readRect(
+            @NonNull Object target,
+            @Nullable Method method,
+            @Nullable Field field
+    ) {
+        final Object value = readObject(target, method, field);
+        return value instanceof Rect ? (Rect) value : null;
+    }
+
+    @Nullable
+    private static Object readObject(
+            @NonNull Object target,
+            @Nullable Method method,
+            @Nullable Field field
+    ) {
+        if (method != null) {
+            try {
+                return method.invoke(target);
+            } catch (ReflectiveOperationException e) {
+                Log.w(TAG, "调用隐藏方法失败", e);
+            }
+        }
+        if (field != null) {
+            return readFieldValue(target, field);
+        }
+        return null;
+    }
+
+    @Nullable
+    private static Object readFieldValue(@NonNull Object target, @NonNull Field field) {
+        try {
+            return field.get(target);
+        } catch (IllegalAccessException e) {
+            Log.w(TAG, "读取隐藏字段失败", e);
+            return null;
+        }
+    }
+
+    @Nullable
+    private static Method findMethod(@NonNull Class<?> type, @NonNull String name) {
+        try {
+            return type.getMethod(name);
+        } catch (NoSuchMethodException ignored) {
+        }
+        try {
+            final Method method = type.getDeclaredMethod(name);
+            method.setAccessible(true);
+            return method;
+        } catch (ReflectiveOperationException e) {
+            Log.w(TAG, "查找隐藏方法失败: " + type.getName() + "#" + name, e);
+            return null;
+        }
+    }
+
+    @Nullable
+    private static Method findMethod(@NonNull String className, @NonNull String name) {
+        final Class<?> type = findClass(className);
+        return type == null ? null : findMethod(type, name);
+    }
+
+    @Nullable
+    private static Field findField(@NonNull Class<?> type, @NonNull String name) {
+        try {
+            return type.getField(name);
+        } catch (NoSuchFieldException ignored) {
+        }
+        try {
+            final Field field = type.getDeclaredField(name);
+            field.setAccessible(true);
+            return field;
+        } catch (ReflectiveOperationException e) {
+            Log.w(TAG, "查找隐藏字段失败: " + type.getName() + "#" + name, e);
+            return null;
+        }
+    }
+
+    @Nullable
+    private static Field findField(@NonNull String className, @NonNull String name) {
+        final Class<?> type = findClass(className);
+        return type == null ? null : findField(type, name);
+    }
+
+    @Nullable
+    private static Class<?> findClass(@NonNull String className) {
+        try {
+            return Class.forName(className);
+        } catch (ClassNotFoundException e) {
+            Log.w(TAG, "查找隐藏类失败: " + className, e);
+            return null;
+        }
+    }
+}

--- a/hiddenapi/compat/src/main/java/yangfentuozi/hiddenapi/compat/TaskInfoCompat.java
+++ b/hiddenapi/compat/src/main/java/yangfentuozi/hiddenapi/compat/TaskInfoCompat.java
@@ -154,8 +154,7 @@ public final class TaskInfoCompat {
         if (method != null) {
             try {
                 return method.invoke(target);
-            } catch (ReflectiveOperationException e) {
-                Log.w(TAG, "调用隐藏方法失败", e);
+            } catch (Throwable ignored) {
             }
         }
         if (field != null) {
@@ -168,8 +167,7 @@ public final class TaskInfoCompat {
     private static Object readFieldValue(@NonNull Object target, @NonNull Field field) {
         try {
             return field.get(target);
-        } catch (IllegalAccessException e) {
-            Log.w(TAG, "读取隐藏字段失败", e);
+        } catch (Throwable ignored) {
             return null;
         }
     }
@@ -184,7 +182,7 @@ public final class TaskInfoCompat {
             final Method method = type.getDeclaredMethod(name);
             method.setAccessible(true);
             return method;
-        } catch (ReflectiveOperationException e) {
+        } catch (Throwable e) {
             Log.w(TAG, "查找隐藏方法失败: " + type.getName() + "#" + name, e);
             return null;
         }
@@ -206,7 +204,7 @@ public final class TaskInfoCompat {
             final Field field = type.getDeclaredField(name);
             field.setAccessible(true);
             return field;
-        } catch (ReflectiveOperationException e) {
+        } catch (Throwable e) {
             Log.w(TAG, "查找隐藏字段失败: " + type.getName() + "#" + name, e);
             return null;
         }
@@ -222,7 +220,7 @@ public final class TaskInfoCompat {
     private static Class<?> findClass(@NonNull String className) {
         try {
             return Class.forName(className);
-        } catch (ClassNotFoundException e) {
+        } catch (Throwable e) {
             Log.w(TAG, "查找隐藏类失败: " + className, e);
             return null;
         }

--- a/hiddenapi/compat/src/main/java/yangfentuozi/hiddenapi/compat/TaskInfoCompat.java
+++ b/hiddenapi/compat/src/main/java/yangfentuozi/hiddenapi/compat/TaskInfoCompat.java
@@ -204,6 +204,8 @@ public final class TaskInfoCompat {
             final Field field = type.getDeclaredField(name);
             field.setAccessible(true);
             return field;
+        } catch (NoSuchFieldException ignored) {
+            return null;
         } catch (Throwable e) {
             Log.w(TAG, "查找隐藏字段失败: " + type.getName() + "#" + name, e);
             return null;

--- a/server/src/main/java/yangfentuozi/batteryrecorder/server/recorder/Monitor.kt
+++ b/server/src/main/java/yangfentuozi/batteryrecorder/server/recorder/Monitor.kt
@@ -385,11 +385,14 @@ class Monitor(
             )
             return
         }
+        val changedForegroundApp = oldForegroundApp != packageName
         LoggerX.v(
             tag,
-            "前台应用检测: source=$source taskId=${taskInfo.taskId} 当前应用包名=$packageName 当前Activity=$className 是否小窗=否 是否切换前台应用=是 当前窗口=$boundsText 最大窗口=$maxBoundsText 旧前台应用=$oldForegroundApp 新前台应用=$packageName"
+            "前台应用检测: source=$source taskId=${taskInfo.taskId} 当前应用包名=$packageName 当前Activity=$className 是否小窗=否 是否切换前台应用=${if (changedForegroundApp) "是" else "否"} 原因=${if (changedForegroundApp) "命中非小窗且包名发生变化" else "命中非小窗但包名未变化"} 当前窗口=$boundsText 最大窗口=$maxBoundsText 旧前台应用=$oldForegroundApp 新前台应用=$packageName"
         )
-        currForegroundApp = packageName
+        if (changedForegroundApp) {
+            currForegroundApp = packageName
+        }
     }
 
     /**

--- a/server/src/main/java/yangfentuozi/batteryrecorder/server/recorder/Monitor.kt
+++ b/server/src/main/java/yangfentuozi/batteryrecorder/server/recorder/Monitor.kt
@@ -29,6 +29,7 @@ import yangfentuozi.batteryrecorder.shared.data.LineRecord
 import yangfentuozi.batteryrecorder.shared.util.Handlers
 import yangfentuozi.batteryrecorder.shared.util.LoggerX
 import yangfentuozi.hiddenapi.compat.ServiceManagerCompat
+import yangfentuozi.hiddenapi.compat.TaskInfoCompat
 import java.io.IOException
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.locks.ReentrantLock
@@ -363,37 +364,30 @@ class Monitor(
     private fun onFocusedAppChanged(taskInfo: TaskInfo, source: String) {
         val oldForegroundApp = currForegroundApp
         val componentName = taskInfo.topActivity
-        val bounds = readTaskWindowConfigurationRectProperty(
-            taskInfo,
-            methodName = "getBounds",
-            fieldName = "bounds"
-        )
-        val maxBounds = readTaskWindowConfigurationRectProperty(
-            taskInfo,
-            methodName = "getMaxBounds",
-            fieldName = "maxBounds"
-        )
+        val bounds = TaskInfoCompat.getBoundsOrNull(taskInfo)
+        val maxBounds = TaskInfoCompat.getMaxBoundsOrNull(taskInfo)
         val boundsText = formatRect(bounds)
         val maxBoundsText = formatRect(maxBounds)
         if (componentName == null) {
             LoggerX.v(
                 tag,
-                "foreground:top-null source=$source taskId=${taskInfo.taskId} bounds=$boundsText maxBounds=$maxBoundsText old=$oldForegroundApp"
+                "前台应用检测: source=$source taskId=${taskInfo.taskId} 当前应用包名=无 是否小窗=未知 是否切换前台应用=否 原因=当前任务没有顶部Activity 当前窗口=$boundsText 最大窗口=$maxBoundsText 旧前台应用=$oldForegroundApp"
             )
             return
         }
         val packageName = componentName.packageName
         val className = componentName.className
-        if (isSmallWindow(bounds, maxBounds)) {
+        val isSmallWindow = isSmallWindow(bounds, maxBounds)
+        if (isSmallWindow) {
             LoggerX.i(
                 tag,
-                "foreground:small-window-ignored source=$source taskId=${taskInfo.taskId} pkg=$packageName cls=$className bounds=$boundsText maxBounds=$maxBoundsText old=$oldForegroundApp new=$packageName"
+                "前台应用检测: source=$source taskId=${taskInfo.taskId} 当前应用包名=$packageName 当前Activity=$className 是否小窗=是 是否切换前台应用=否 原因=命中小窗规则 当前窗口=$boundsText 最大窗口=$maxBoundsText 旧前台应用=$oldForegroundApp"
             )
             return
         }
         LoggerX.v(
             tag,
-            "foreground:$source taskId=${taskInfo.taskId} pkg=$packageName cls=$className bounds=$boundsText maxBounds=$maxBoundsText old=$oldForegroundApp new=$packageName"
+            "前台应用检测: source=$source taskId=${taskInfo.taskId} 当前应用包名=$packageName 当前Activity=$className 是否小窗=否 是否切换前台应用=是 当前窗口=$boundsText 最大窗口=$maxBoundsText 旧前台应用=$oldForegroundApp 新前台应用=$packageName"
         )
         currForegroundApp = packageName
     }
@@ -424,63 +418,6 @@ class Monitor(
     private fun formatRect(rect: Rect?): String {
         if (rect == null) return "unavailable"
         return "[${rect.left},${rect.top},${rect.right},${rect.bottom}]"
-    }
-
-    /**
-     * 通过 `TaskInfo -> Configuration -> WindowConfiguration` 反射读取窗口配置对象上的 `Rect` 属性。
-     *
-     * @param taskInfo 当前任务栈信息。
-     * @param methodName 优先尝试调用的 WindowConfiguration getter 方法名。
-     * @param fieldName getter 不可用时尝试读取的 WindowConfiguration 字段名。
-     * @return 成功时返回窗口边界；成员不存在或类型不符返回 `null`。
-     */
-    private fun readTaskWindowConfigurationRectProperty(
-        taskInfo: TaskInfo,
-        methodName: String,
-        fieldName: String
-    ): Rect? {
-        val configuration = readProperty(taskInfo, "getConfiguration", "configuration")
-            ?: return null
-        val windowConfiguration =
-            readProperty(configuration, "getWindowConfiguration", "windowConfiguration")
-                ?: return null
-        return readProperty(windowConfiguration, methodName, fieldName) as? Rect
-    }
-
-    /**
-     * 通过反射读取对象属性，优先 getter，其次字段；同时兼容 public 与 declared 成员。
-     *
-     * @param target 要读取属性的对象。
-     * @param methodName 优先尝试调用的 getter 方法名。
-     * @param fieldName getter 不可用时尝试读取的字段名。
-     * @return 读取成功返回属性值，否则返回 `null`。
-     */
-    private fun readProperty(target: Any, methodName: String, fieldName: String): Any? {
-        try {
-            return target.javaClass.getMethod(methodName).invoke(target)
-        } catch (_: NoSuchMethodException) {
-        }
-
-        try {
-            val method = target.javaClass.getDeclaredMethod(methodName)
-            method.isAccessible = true
-            return method.invoke(target)
-        } catch (_: NoSuchMethodException) {
-        }
-
-        try {
-            return target.javaClass.getField(fieldName).get(target)
-        } catch (_: NoSuchFieldException) {
-        }
-
-        try {
-            val field = target.javaClass.getDeclaredField(fieldName)
-            field.isAccessible = true
-            return field.get(target)
-        } catch (_: NoSuchFieldException) {
-        }
-
-        return null
     }
 
     // 耗时操作

--- a/server/src/main/java/yangfentuozi/batteryrecorder/server/recorder/Monitor.kt
+++ b/server/src/main/java/yangfentuozi/batteryrecorder/server/recorder/Monitor.kt
@@ -371,7 +371,12 @@ class Monitor(
         if (componentName == null) {
             LoggerX.v(
                 tag,
-                "前台应用检测: source=$source taskId=${taskInfo.taskId} 当前应用包名=无 是否小窗=未知 是否切换前台应用=否 原因=当前任务没有顶部Activity 当前窗口=$boundsText 最大窗口=$maxBoundsText 旧前台应用=$oldForegroundApp"
+                "前台应用检测: source=%s taskId=%d 当前应用包名=无 是否小窗=未知 是否切换前台应用=否 原因=当前任务没有顶部Activity 当前窗口=%s 最大窗口=%s 旧前台应用=%s",
+                source,
+                taskInfo.taskId,
+                boundsText,
+                maxBoundsText,
+                oldForegroundApp
             )
             return
         }
@@ -379,16 +384,33 @@ class Monitor(
         val className = componentName.className
         val isSmallWindow = isSmallWindow(bounds, maxBounds)
         if (isSmallWindow) {
-            LoggerX.i(
+            LoggerX.d(
                 tag,
-                "前台应用检测: source=$source taskId=${taskInfo.taskId} 当前应用包名=$packageName 当前Activity=$className 是否小窗=是 是否切换前台应用=否 原因=命中小窗规则 当前窗口=$boundsText 最大窗口=$maxBoundsText 旧前台应用=$oldForegroundApp"
+                "前台应用检测: source=%s taskId=%d 当前应用包名=%s 当前Activity=%s 是否小窗=是 是否切换前台应用=否 原因=命中小窗规则 当前窗口=%s 最大窗口=%s 旧前台应用=%s",
+                source,
+                taskInfo.taskId,
+                packageName,
+                className,
+                boundsText,
+                maxBoundsText,
+                oldForegroundApp
             )
             return
         }
         val changedForegroundApp = oldForegroundApp != packageName
         LoggerX.v(
             tag,
-            "前台应用检测: source=$source taskId=${taskInfo.taskId} 当前应用包名=$packageName 当前Activity=$className 是否小窗=否 是否切换前台应用=${if (changedForegroundApp) "是" else "否"} 原因=${if (changedForegroundApp) "命中非小窗且包名发生变化" else "命中非小窗但包名未变化"} 当前窗口=$boundsText 最大窗口=$maxBoundsText 旧前台应用=$oldForegroundApp 新前台应用=$packageName"
+            "前台应用检测: source=%s taskId=%d 当前应用包名=%s 当前Activity=%s 是否小窗=否 是否切换前台应用=%s 原因=%s 当前窗口=%s 最大窗口=%s 旧前台应用=%s 新前台应用=%s",
+            source,
+            taskInfo.taskId,
+            packageName,
+            className,
+            if (changedForegroundApp) "是" else "否",
+            if (changedForegroundApp) "命中非小窗且包名发生变化" else "命中非小窗但包名未变化",
+            boundsText,
+            maxBoundsText,
+            oldForegroundApp,
+            packageName
         )
         if (changedForegroundApp) {
             currForegroundApp = packageName


### PR DESCRIPTION
- 新增 `TaskInfoCompat` 工具类，统一通过反射获取 `TaskInfo` 的窗口边界（Bounds）和最大窗口边界（MaxBounds）。
- 重构 `Monitor.kt` 中的前台应用检测逻辑，移除冗余的反射代码。
- 优化前台应用切换时的日志输出，将其转换为更易读的中文描述，并详细记录任务 ID、包名、小窗状态及窗口尺寸信息。