### PR TITLE
improve: 强化 Server 端对 App 安装态变化的检测机制

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ BatteryRecorder 是一个 Android 电池功率记录 App。
 - Root/ADB 启动当前统一通过原生 `libstarter.so` 拉起 `app_process`；root 启动会显式传入 APK 路径，ADB/shell 启动可回退到 `pm path` 解析 APK 路径
 - 采样优先走 JNI sysfs 读取；不可用时回退到 dumpsys/batteryproperties 方案
 - root 模式下主 `Server` 会额外派生独立的 `NotificationServer` 子进程，并通过本地 socket 转发实时通知
-- App 更新时，root 模式 `Server` 会监听 APK sourceDir 变化并自动拉起新的 `libstarter.so`；新旧 `Server` 会尝试交接当前记录写入状态以续接记录
+- App 更新时，root 模式 `Server` 会同时依赖 `AppSourceDirObserver` 的被动监听、`BinderSender` 在 Binder 重推前的主动检查，以及 `IService` 入口前的主动检查；命中更新后会自动拉起新的 `libstarter.so`，新旧 `Server` 会尝试交接当前记录写入状态以续接记录
 - 历史数据支持图表查看、应用维度统计、场景维度统计、记录详情统计、记录详情长截图导出与续航预测
 - 应用启动阶段还负责首次启动引导、文档引导与更新检查；启动引导与文档引导是两条独立链路，前者由 `StartupGuideScreen` 承载，后者应保持独立弹窗形态；更新检查当前支持“稳定版 / 预发布”两种通道，更新弹窗支持浏览器打开或走系统 `DownloadManager` 下载安装；首页同时提供 Root/ADB 启动入口与日志导出，历史列表页顶部菜单负责记录清理以及历史导入/导出
 
@@ -74,8 +74,8 @@ App 进程 (UI)  <->  AIDL Binder  <->  Server 进程 (root/shell)
 - 进程入口为 `server/.../Main.kt`
 - `Main.kt` 会根据启动参数区分主 `Server` 与 `NotificationServer`，并负责设置进程名、`oom_score_adj` 与 cgroup
 - Server 启动后通过 `ActivityManagerCompat.contentProviderCall()` 将 Binder 推送给 App 的 `BinderProvider`
-- `BinderSender` 会注册 Process/Uid 观察者，在 App 进程重新活跃时持续重推 Binder，减少冷启动和被系统回收后的连接丢失
-- App 通过 `IService` AIDL 与 Server 通信，核心能力包括停止服务、注册监听、更新配置、同步数据
+- `BinderSender` 会注册 Process/Uid 观察者，在 App 进程重新活跃时持续重推 Binder；真正推送前会先执行 `Server.checkAppReinstall(...)`，减少冷启动和被系统回收后的连接丢失，同时更早发现 App 更新或卸载
+- App 通过 `IService` AIDL 与 Server 通信，核心能力包括停止服务、注册监听、更新配置、同步数据；服务端各入口在执行业务前都会先执行 `Server.checkAppReinstall(...)`
 - Server 读取配置时：
   - root 权限：直接读 App 的 SharedPreferences XML
   - shell 权限：通过 `ConfigProvider`
@@ -85,7 +85,7 @@ App 进程 (UI)  <->  AIDL Binder  <->  Server 进程 (root/shell)
 - 首页 Root 启动、开机 ROOT 自启动、ADB 引导当前都统一指向 `libstarter.so`
 - `RootServerStarter` 会构造 `libstarter.so --apk=<sourceDir>` 命令；ADB 引导文案默认展示直接执行 `libstarter.so` 的命令
 - `starter.cpp` 负责校验调用 UID、解析 APK 路径、设置 `CLASSPATH`，再用 `app_process` 拉起 `yangfentuozi.batteryrecorder.server.Main`
-- `Server` 初始化时会启动 `AppSourceDirObserver` 监听 `Global.appSourceDir`；检测到 APK 更新后会直接拉起新 `libstarter.so`，检测到卸载则退出当前服务
+- `Server` 初始化时会启动 `AppSourceDirObserver` 监听 `Global.appSourceDir`；该监听、`BinderSender` 重推前检查以及 `IService` 入口前检查当前都统一收口到 `Server.checkAppReinstall(...)`，检测到 APK 更新后会直接拉起新 `libstarter.so`，检测到卸载则退出当前服务
 - 新旧 `Server` 之间会通过 `BatteryRecorder_Server` 本地 socket 交接 `PowerRecordWriter.WriterStatusData`；旧进程在退出前发送当前 writer 状态，新进程启动后优先尝试续接原分段文件
 - root 模式下，`Server` 初始化时会创建 `ChildServerBridge`，再派生 `NotificationServer`
 - `NotificationServer` 启动后会降权到 shell uid 2000，等待 `notification` / `activity` 服务可用，并用 `LocalServerSocket` 接收主 `Server` 发来的通知流
@@ -374,12 +374,12 @@ docs/
 - 页面级沉浸规则是：`Scaffold` 只吃顶部/水平安全区，底部手势区由内容层自行处理
 - 页面外层 margin 当前统一按 16.dp 收敛；若看到 24.dp，需要先确认那是不是组件内部排版或图表绘制留白，而不是页面 margin
 - ROOT 启动统一经过 `RootServerStarter.start(context, source)`
-- root 模式下 `Server` 会启动 `AppSourceDirObserver` 监听 APK 路径变化；修改启动/更新链路时必须同时检查自动重启与卸载退出行为
+- root 模式下 `Server` 会通过 `AppSourceDirObserver`、`BinderSender` 重推前检查和 `IService` 入口前检查共同监测 App 安装态变化；修改启动/更新链路时必须同时检查自动重启与卸载退出行为，以及 `Server.checkAppReinstall(...)` 的统一判定口径
 - App 更新后的自动续接记录依赖 `server/stream/*` 与 `PowerRecordWriter.WriterStatusData`；修改当前记录分段、关闭逻辑或 writer 状态字段时必须同步检查这条交接链路
 - root 模式下主 `Server` 会派生 `NotificationServer` 子进程处理通知；通知相关改动必须同时检查 `ChildServerBridge`、socket 协议与 `LocalNotificationUtil`
 - `NotificationServer` 依赖 `FakeContext` 获取可用 `Context` 与外部 Provider；修改通知链路时不要假设它运行在常规 Android `Application` 环境中
 - `LocalNotificationUtil` 当前通过复用 `Notification.Builder` 承担通知更新的性能优化；修改通知字段时不要无意退回到“每次更新都新建 Builder”的实现
-- `Server` 初始化末尾会创建 `BinderSender`；修改 Binder 建连或进程恢复逻辑时必须同时检查 ProcessObserver / UidObserver 重推行为
+- `Server` 初始化末尾会创建 `BinderSender`；修改 Binder 建连或进程恢复逻辑时必须同时检查 ProcessObserver / UidObserver 重推行为，以及重推前的 `Server.checkAppReinstall(...)`
 - 当前设置系统按 `AppSettings`、`StatisticsSettings`、`ServerSettings` 分层；`ServerSettingsCodec.kt` 是 `ServerSettings` 字段映射的唯一入口，`SharedSettings.kt` 负责三类设置的 SharedPreferences 读写入口，`ConfigUtil.kt` 只负责 root/shell 两条来源适配
 - `ServerSettings` 当前同时承载服务端运行参数与功率展示共用配置；`notificationEnabled`、`dualCellEnabled`、`calibrationValue` 都属于 `ServerSettings`，其中后两者由 App 展示侧直接复用；`calibrationValue` 当前语义是“原始电流到实际功率 / Wh 的换算倍率”，不是电流单位枚举
 - 更新检测通道属于 `AppSettings`，当前字段为 `AppSettings.updateChannel`，使用 `UpdateChannel` 枚举持久化

--- a/server/src/main/java/yangfentuozi/batteryrecorder/server/AppSourceDirObserver.kt
+++ b/server/src/main/java/yangfentuozi/batteryrecorder/server/AppSourceDirObserver.kt
@@ -1,12 +1,9 @@
 package yangfentuozi.batteryrecorder.server
 
-import android.content.pm.ApplicationInfo
 import android.os.FileObserver
-import yangfentuozi.batteryrecorder.shared.Constants
-import yangfentuozi.hiddenapi.compat.PackageManagerCompat
 import java.io.File
 
-class AppSourceDirObserver(val onAppSourceDirChanged: (ApplicationInfo?) -> Unit) :
+class AppSourceDirObserver(private val checkAppReinstall: (String) -> Boolean) :
     FileObserver(
         File(Global.appSourceDir), MODIFY or ATTRIB or CLOSE_WRITE
                 or CLOSE_NOWRITE or OPEN or MOVED_FROM or MOVED_TO or DELETE or CREATE
@@ -14,16 +11,8 @@ class AppSourceDirObserver(val onAppSourceDirChanged: (ApplicationInfo?) -> Unit
     ) {
 
     override fun onEvent(event: Int, path: String?) {
-        val appInfo = runCatching {
-            PackageManagerCompat.getApplicationInfo(
-                Constants.APP_PACKAGE_NAME,
-                0L,
-                0
-            )
-        }.getOrNull()
-        if (appInfo?.sourceDir != Global.appSourceDir || !File(Global.appSourceDir).exists()) {
+        if (!checkAppReinstall("AppSourceDirObserver")) {
             stopWatching()
-            onAppSourceDirChanged(appInfo)
         }
     }
 }

--- a/server/src/main/java/yangfentuozi/batteryrecorder/server/Server.kt
+++ b/server/src/main/java/yangfentuozi/batteryrecorder/server/Server.kt
@@ -55,14 +55,17 @@ class Server internal constructor() : IService.Stub() {
     private var shellPowerDataDir: File
 
     override fun stopService() {
-        Handlers.main.postDelayed({ exitProcess(0) }, 100)
+        ensureAppReady("stopService")
+        stopServiceInternal("stopService")
     }
 
     override fun getVersion(): Int {
+        ensureAppReady("getVersion")
         return BuildConfig.VERSION
     }
 
     override fun getCurrRecordsFile(): RecordsFile? {
+        ensureAppReady("getCurrRecordsFile")
         return RecordsFile.fromFile(
             when (writer.lastStatus) {
                 Charging -> writer.chargeDataWriter.getCurrFile(writer.chargeDataWriter.hasPendingStatusChange)
@@ -73,10 +76,12 @@ class Server internal constructor() : IService.Stub() {
     }
 
     override fun registerRecordListener(listener: IRecordListener) {
+        ensureAppReady("registerRecordListener")
         monitor.registerRecordListener(listener)
     }
 
     override fun unregisterRecordListener(listener: IRecordListener) {
+        ensureAppReady("unregisterRecordListener")
         monitor.unregisterRecordListener(listener)
     }
 
@@ -116,6 +121,7 @@ class Server internal constructor() : IService.Stub() {
     }
 
     override fun updateConfig(settings: ServerSettings) {
+        ensureAppReady("updateConfig")
         Handlers.common.post {
             applyConfigInternal(settings, "updateConfig")
         }
@@ -181,6 +187,7 @@ class Server internal constructor() : IService.Stub() {
     }
 
     override fun sync(): ParcelFileDescriptor? {
+        ensureAppReady("sync")
         writer.flushBufferBlocking()
         if (Os.getuid() == 0) {
             LoggerX.d(tag, "sync: root 模式不需要同步文件, return null")
@@ -243,6 +250,7 @@ class Server internal constructor() : IService.Stub() {
      * @return 用于读取日志目录文件流的管道读端。
      */
     override fun exportLogs(): ParcelFileDescriptor {
+        ensureAppReady("exportLogs")
         val logDir = File("${Constants.SHELL_DATA_DIR_PATH}/${Constants.SHELL_LOG_DIR_PATH}")
         LoggerX.i(tag, "exportLogs: 收到服务端日志导出请求", notWrite = true)
         LoggerX.d(tag, "exportLogs: 服务端日志目录 dir=${logDir.absolutePath}", notWrite = true)
@@ -307,6 +315,71 @@ class Server internal constructor() : IService.Stub() {
         return readEnd
     }
 
+    /**
+     * 在处理对外 IPC 之前确认 App 安装态是否仍与当前 Server 绑定的 APK 一致。
+     *
+     * @param trigger 触发本次校验的入口名称，仅用于日志定位。
+     * @return 无。
+     * @throws RemoteException 当检测到 App 已更新、重装或卸载时抛出，阻止继续执行业务 IPC。
+     */
+    private fun ensureAppReady(trigger: String) {
+        if (!checkAppReinstall(trigger)) {
+            throw RemoteException("$trigger: App 已更新、重装或卸载")
+        }
+    }
+
+    /**
+     * 检查当前 App 是否已更新、重装或卸载，并在命中变化时复用既有处理链路。
+     *
+     * @param trigger 触发本次检查的入口名称，仅用于日志定位。
+     * @return `true` 表示当前安装态未变化，可以继续执行；`false` 表示已转交
+     * `onAppSourceDirChanged(...)` 处理，不应继续当前业务。
+     */
+    private fun checkAppReinstall(trigger: String): Boolean {
+        val appInfo = try {
+            PackageManagerCompat.getApplicationInfo(Constants.APP_PACKAGE_NAME, 0L, 0)
+        } catch (e: RemoteException) {
+            LoggerX.e(tag, "$trigger: 查询 App 安装信息失败，跳过本次重装检查", tr = e)
+            return true
+        } catch (e: PackageManager.NameNotFoundException) {
+            LoggerX.w(tag, "$trigger: 查询 App 安装信息失败，按已卸载处理", tr = e)
+            onAppSourceDirChanged(null)
+            return false
+        }
+
+        if (appInfo.sourceDir == null || appInfo.nativeLibraryDir == null) {
+            LoggerX.w(
+                tag,
+                "$trigger: App 安装信息不完整，按已卸载处理 sourceDir=${appInfo.sourceDir} nativeLibraryDir=${appInfo.nativeLibraryDir}"
+            )
+            onAppSourceDirChanged(appInfo)
+            return false
+        }
+
+        val recordedSourceDir = Global.appSourceDir
+        val sourceDirExists = File(recordedSourceDir).exists()
+        if (appInfo.sourceDir != recordedSourceDir || !sourceDirExists) {
+            LoggerX.i(
+                tag,
+                "$trigger: 检测到 App 安装态变化 oldSourceDir=$recordedSourceDir newSourceDir=${appInfo.sourceDir} oldExists=$sourceDirExists"
+            )
+            onAppSourceDirChanged(appInfo)
+            return false
+        }
+        return true
+    }
+
+    /**
+     * 直接安排当前 Server 进程退出，不执行 IPC 入口的安装态检查。
+     *
+     * @param trigger 触发本次退出的来源，仅用于日志定位。
+     * @return 无。
+     */
+    private fun stopServiceInternal(trigger: String) {
+        LoggerX.i(tag, "$trigger: 安排退出当前 Server 进程")
+        Handlers.main.postDelayed({ exitProcess(0) }, 100)
+    }
+
     private fun onStop() {
         monitor.stop()
 
@@ -354,7 +427,7 @@ class Server internal constructor() : IService.Stub() {
         onAppSourceDirChangedInvoked = true
         if (appInfo == null || appInfo.sourceDir == null || appInfo.nativeLibraryDir == null) {
             LoggerX.i(tag, "onAppSourceDirChanged: App 已被卸载, 退出服务")
-            stopService()
+            stopServiceInternal("onAppSourceDirChanged")
         } else {
             LoggerX.i(tag, "onAppSourceDirChanged: App 已被更新, 重启服务")
             ProcessBuilder(appInfo.nativeLibraryDir + "/libstarter.so").start()
@@ -398,7 +471,7 @@ class Server internal constructor() : IService.Stub() {
         appConfigFile = File("${appInfo.dataDir}/shared_prefs/${SettingsConstants.PREFS_NAME}.xml")
         appPowerDataDir = File("${appInfo.dataDir}/${Constants.APP_POWER_DATA_PATH}")
 
-        appSourceDirObserver = AppSourceDirObserver(::onAppSourceDirChanged)
+        appSourceDirObserver = AppSourceDirObserver(::checkAppReinstall)
         appSourceDirObserver.startWatching()
 
         val sampler = if (SysfsSampler.init(appInfo)) SysfsSampler else DumpsysSampler()
@@ -489,7 +562,11 @@ class Server internal constructor() : IService.Stub() {
         LoggerX.i(tag, "init: Monitor 已启动, 进入消息循环")
 
         LoggerX.i(tag, "init: 初始化 BinderSender")
-        BinderSender(::sendBinder)
+        BinderSender {
+            if (checkAppReinstall("BinderSender")) {
+                sendBinder()
+            }
+        }
 
         Thread({
             Thread.sleep(1000)
@@ -522,7 +599,7 @@ class Server internal constructor() : IService.Stub() {
                 var line: String
                 while ((scanner.nextLine().also { line = it }) != null) {
                     if (line.trim { it <= ' ' } == "exit") {
-                        stopService()
+                        stopServiceInternal("InputHandler")
                     }
                 }
                 scanner.close()

--- a/server/src/main/java/yangfentuozi/batteryrecorder/server/Server.kt
+++ b/server/src/main/java/yangfentuozi/batteryrecorder/server/Server.kt
@@ -39,6 +39,7 @@ import java.io.FileDescriptor
 import java.io.IOException
 import java.nio.file.Files
 import java.util.Scanner
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.system.exitProcess
 
 class Server internal constructor() : IService.Stub() {
@@ -55,7 +56,6 @@ class Server internal constructor() : IService.Stub() {
     private var shellPowerDataDir: File
 
     override fun stopService() {
-        ensureAppReady("stopService")
         stopServiceInternal("stopService")
     }
 
@@ -420,11 +420,10 @@ class Server internal constructor() : IService.Stub() {
         }
     }
 
-    private var onAppSourceDirChangedInvoked = false
+    private val onAppSourceDirChangedInvoked = AtomicBoolean(false)
 
     private fun onAppSourceDirChanged(appInfo: ApplicationInfo?) {
-        if (onAppSourceDirChangedInvoked) return
-        onAppSourceDirChangedInvoked = true
+        if (!onAppSourceDirChangedInvoked.compareAndSet(false, true)) return
         if (appInfo == null || appInfo.sourceDir == null || appInfo.nativeLibraryDir == null) {
             LoggerX.i(tag, "onAppSourceDirChanged: App 已被卸载, 退出服务")
             stopServiceInternal("onAppSourceDirChanged")

--- a/server/src/main/java/yangfentuozi/batteryrecorder/server/Server.kt
+++ b/server/src/main/java/yangfentuozi/batteryrecorder/server/Server.kt
@@ -339,10 +339,10 @@ class Server internal constructor() : IService.Stub() {
         val appInfo = try {
             PackageManagerCompat.getApplicationInfo(Constants.APP_PACKAGE_NAME, 0L, 0)
         } catch (e: RemoteException) {
-            LoggerX.e(tag, "$trigger: 查询 App 安装信息失败，跳过本次重装检查", tr = e)
+            LoggerX.e(tag, "$trigger: 查询 App 安装信息失败, 跳过本次重装检查", tr = e)
             return true
         } catch (e: PackageManager.NameNotFoundException) {
-            LoggerX.w(tag, "$trigger: 查询 App 安装信息失败，按已卸载处理", tr = e)
+            LoggerX.w(tag, "$trigger: 查询 App 安装信息失败, 按已卸载处理", tr = e)
             onAppSourceDirChanged(null)
             return false
         }
@@ -350,7 +350,7 @@ class Server internal constructor() : IService.Stub() {
         if (appInfo.sourceDir == null || appInfo.nativeLibraryDir == null) {
             LoggerX.w(
                 tag,
-                "$trigger: App 安装信息不完整，按已卸载处理 sourceDir=${appInfo.sourceDir} nativeLibraryDir=${appInfo.nativeLibraryDir}"
+                "$trigger: App 安装信息不完整, 按已卸载处理 sourceDir=${appInfo.sourceDir} nativeLibraryDir=${appInfo.nativeLibraryDir}"
             )
             onAppSourceDirChanged(appInfo)
             return false


### PR DESCRIPTION
- 在 `Server` 中引入 `checkAppReinstall` 统一校验逻辑，并将其整合至 `IService` 接口入口、`BinderSender` 重推前以及 `AppSourceDirObserver` 监听中。
- 当检测到 App 更新、重装或卸载时，自动触发服务重启或退出，提高 root 模式下记录续接的可靠性。
- 完善 `AGENTS.md` 文档中关于 root 模式下 Server 维护机制的说明。