### PR TITLE
refactor: 小窗判断改为 HiddenAPI

### DIFF
--- a/hiddenapi/compat/src/main/java/yangfentuozi/hiddenapi/compat/TaskInfoCompat.java
+++ b/hiddenapi/compat/src/main/java/yangfentuozi/hiddenapi/compat/TaskInfoCompat.java
@@ -1,56 +1,14 @@
 package yangfentuozi.hiddenapi.compat;
 
+import android.app.ActivityTaskManager;
+import android.app.IActivityTaskManager;
 import android.app.TaskInfo;
 import android.graphics.Rect;
-import android.util.Log;
+import android.os.RemoteException;
 
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-
 public final class TaskInfoCompat {
-    private static final String TAG = "TaskInfoCompat";
-
-    @Nullable
-    private static volatile Accessor accessor;
-
-    private static final class Accessor {
-        @Nullable
-        final Method taskInfoGetConfigurationMethod;
-        @Nullable
-        final Field taskInfoConfigurationField;
-        @Nullable
-        final Field configurationWindowConfigurationField;
-        @Nullable
-        final Method windowConfigurationGetBoundsMethod;
-        @Nullable
-        final Field windowConfigurationBoundsField;
-        @Nullable
-        final Method windowConfigurationGetMaxBoundsMethod;
-        @Nullable
-        final Field windowConfigurationMaxBoundsField;
-
-        private Accessor(
-                @Nullable Method taskInfoGetConfigurationMethod,
-                @Nullable Field taskInfoConfigurationField,
-                @Nullable Field configurationWindowConfigurationField,
-                @Nullable Method windowConfigurationGetBoundsMethod,
-                @Nullable Field windowConfigurationBoundsField,
-                @Nullable Method windowConfigurationGetMaxBoundsMethod,
-                @Nullable Field windowConfigurationMaxBoundsField
-        ) {
-            this.taskInfoGetConfigurationMethod = taskInfoGetConfigurationMethod;
-            this.taskInfoConfigurationField = taskInfoConfigurationField;
-            this.configurationWindowConfigurationField = configurationWindowConfigurationField;
-            this.windowConfigurationGetBoundsMethod = windowConfigurationGetBoundsMethod;
-            this.windowConfigurationBoundsField = windowConfigurationBoundsField;
-            this.windowConfigurationGetMaxBoundsMethod = windowConfigurationGetMaxBoundsMethod;
-            this.windowConfigurationMaxBoundsField = windowConfigurationMaxBoundsField;
-        }
-    }
-
     private TaskInfoCompat() {
     }
 
@@ -61,20 +19,18 @@ public final class TaskInfoCompat {
      * @return 成功返回窗口当前边界，任务为空时返回 `null`。
      */
     @Nullable
-    public static Rect getBoundsOrNull(@Nullable TaskInfo taskInfo) {
+    public static Rect getBoundsOrNull(
+            IActivityTaskManager activityTaskManager,
+            @Nullable TaskInfo taskInfo,
+            @Nullable ActivityTaskManager.RootTaskInfo focusedRootTaskInfo
+    ) throws RemoteException {
         if (taskInfo == null) {
             return null;
         }
-        final Accessor currentAccessor = getAccessor();
-        final Object windowConfiguration = readWindowConfiguration(taskInfo, currentAccessor);
-        if (windowConfiguration == null) {
-            return null;
+        if (taskInfo instanceof ActivityTaskManager.RootTaskInfo) {
+            return getTopChildBoundsOrRootBounds(focusedRootTaskInfo);
         }
-        return readRect(
-                windowConfiguration,
-                currentAccessor.windowConfigurationGetBoundsMethod,
-                currentAccessor.windowConfigurationBoundsField
-        );
+        return activityTaskManager.getTaskBounds(taskInfo.taskId);
     }
 
     /**
@@ -84,147 +40,30 @@ public final class TaskInfoCompat {
      * @return 成功返回窗口最大边界，任务为空时返回 `null`。
      */
     @Nullable
-    public static Rect getMaxBoundsOrNull(@Nullable TaskInfo taskInfo) {
-        if (taskInfo == null) {
+    public static Rect getMaxBoundsOrNull(@Nullable ActivityTaskManager.RootTaskInfo focusedRootTaskInfo) {
+        if (focusedRootTaskInfo == null) {
             return null;
         }
-        final Accessor currentAccessor = getAccessor();
-        final Object windowConfiguration = readWindowConfiguration(taskInfo, currentAccessor);
-        if (windowConfiguration == null) {
-            return null;
-        }
-        return readRect(
-                windowConfiguration,
-                currentAccessor.windowConfigurationGetMaxBoundsMethod,
-                currentAccessor.windowConfigurationMaxBoundsField
-        );
+        return focusedRootTaskInfo.bounds;
     }
 
-    @NonNull
-    private static Accessor getAccessor() {
-        final Accessor cached = accessor;
-        if (cached != null) {
-            return cached;
-        }
-        final Accessor created = new Accessor(
-                findMethod(TaskInfo.class, "getConfiguration"),
-                findField(TaskInfo.class, "configuration"),
-                findField("android.content.res.Configuration", "windowConfiguration"),
-                findMethod("android.app.WindowConfiguration", "getBounds"),
-                findField("android.app.WindowConfiguration", "bounds"),
-                findMethod("android.app.WindowConfiguration", "getMaxBounds"),
-                findField("android.app.WindowConfiguration", "maxBounds")
-        );
-        accessor = created;
-        return created;
-    }
-
+    /**
+     * 从 RootTaskInfo 的顶部子任务读取当前任务边界。
+     *
+     * @param focusedRootTaskInfo 当前聚焦 RootTask 信息。
+     * @return 优先返回顶部子任务边界；缺失时返回 RootTask 自身边界。
+     */
     @Nullable
-    private static Object readWindowConfiguration(
-            @NonNull TaskInfo taskInfo,
-            @NonNull Accessor accessor
+    private static Rect getTopChildBoundsOrRootBounds(
+            @Nullable ActivityTaskManager.RootTaskInfo focusedRootTaskInfo
     ) {
-        final Object configuration = readObject(
-                taskInfo,
-                accessor.taskInfoGetConfigurationMethod,
-                accessor.taskInfoConfigurationField
-        );
-        if (configuration == null || accessor.configurationWindowConfigurationField == null) {
+        if (focusedRootTaskInfo == null) {
             return null;
         }
-        return readFieldValue(configuration, accessor.configurationWindowConfigurationField);
-    }
-
-    @Nullable
-    private static Rect readRect(
-            @NonNull Object target,
-            @Nullable Method method,
-            @Nullable Field field
-    ) {
-        final Object value = readObject(target, method, field);
-        return value instanceof Rect ? (Rect) value : null;
-    }
-
-    @Nullable
-    private static Object readObject(
-            @NonNull Object target,
-            @Nullable Method method,
-            @Nullable Field field
-    ) {
-        if (method != null) {
-            try {
-                return method.invoke(target);
-            } catch (Throwable ignored) {
-            }
+        final Rect[] childTaskBounds = focusedRootTaskInfo.childTaskBounds;
+        if (childTaskBounds != null && childTaskBounds.length > 0) {
+            return childTaskBounds[childTaskBounds.length - 1];
         }
-        if (field != null) {
-            return readFieldValue(target, field);
-        }
-        return null;
-    }
-
-    @Nullable
-    private static Object readFieldValue(@NonNull Object target, @NonNull Field field) {
-        try {
-            return field.get(target);
-        } catch (Throwable ignored) {
-            return null;
-        }
-    }
-
-    @Nullable
-    private static Method findMethod(@NonNull Class<?> type, @NonNull String name) {
-        try {
-            return type.getMethod(name);
-        } catch (NoSuchMethodException ignored) {
-        }
-        try {
-            final Method method = type.getDeclaredMethod(name);
-            method.setAccessible(true);
-            return method;
-        } catch (Throwable e) {
-            Log.w(TAG, "查找隐藏方法失败: " + type.getName() + "#" + name, e);
-            return null;
-        }
-    }
-
-    @Nullable
-    private static Method findMethod(@NonNull String className, @NonNull String name) {
-        final Class<?> type = findClass(className);
-        return type == null ? null : findMethod(type, name);
-    }
-
-    @Nullable
-    private static Field findField(@NonNull Class<?> type, @NonNull String name) {
-        try {
-            return type.getField(name);
-        } catch (NoSuchFieldException ignored) {
-        }
-        try {
-            final Field field = type.getDeclaredField(name);
-            field.setAccessible(true);
-            return field;
-        } catch (NoSuchFieldException ignored) {
-            return null;
-        } catch (Throwable e) {
-            Log.w(TAG, "查找隐藏字段失败: " + type.getName() + "#" + name, e);
-            return null;
-        }
-    }
-
-    @Nullable
-    private static Field findField(@NonNull String className, @NonNull String name) {
-        final Class<?> type = findClass(className);
-        return type == null ? null : findField(type, name);
-    }
-
-    @Nullable
-    private static Class<?> findClass(@NonNull String className) {
-        try {
-            return Class.forName(className);
-        } catch (Throwable e) {
-            Log.w(TAG, "查找隐藏类失败: " + className, e);
-            return null;
-        }
+        return focusedRootTaskInfo.bounds;
     }
 }

--- a/hiddenapi/compat/src/main/java/yangfentuozi/hiddenapi/compat/TaskInfoCompat.java
+++ b/hiddenapi/compat/src/main/java/yangfentuozi/hiddenapi/compat/TaskInfoCompat.java
@@ -15,7 +15,9 @@ public final class TaskInfoCompat {
     /**
      * 读取任务当前窗口边界；任务为空时返回空。
      *
+     * @param activityTaskManager ActivityTaskManager Binder 接口，用于按任务 ID 读取普通任务边界。
      * @param taskInfo 任务信息。
+     * @param focusedRootTaskInfo 当前聚焦 RootTask 信息；仅在 RootTaskInfo 缺少子任务边界时作为后备。
      * @return 成功返回窗口当前边界，任务为空时返回 `null`。
      */
     @Nullable
@@ -28,7 +30,10 @@ public final class TaskInfoCompat {
             return null;
         }
         if (taskInfo instanceof ActivityTaskManager.RootTaskInfo) {
-            return getTopChildBoundsOrRootBounds(focusedRootTaskInfo);
+            return getTopChildBoundsOrRootBounds(
+                    (ActivityTaskManager.RootTaskInfo) taskInfo,
+                    focusedRootTaskInfo
+            );
         }
         return activityTaskManager.getTaskBounds(taskInfo.taskId);
     }
@@ -36,7 +41,7 @@ public final class TaskInfoCompat {
     /**
      * 读取任务可达到的最大窗口边界；任务为空时返回空。
      *
-     * @param taskInfo 任务信息。
+     * @param focusedRootTaskInfo 当前聚焦 RootTask 信息，用于提供最大窗口边界。
      * @return 成功返回窗口最大边界，任务为空时返回 `null`。
      */
     @Nullable
@@ -50,20 +55,29 @@ public final class TaskInfoCompat {
     /**
      * 从 RootTaskInfo 的顶部子任务读取当前任务边界。
      *
-     * @param focusedRootTaskInfo 当前聚焦 RootTask 信息。
+     * @param rootTaskInfo 当前任务对应的 RootTask 信息。
+     * @param fallbackRootTaskInfo 后备 RootTask 信息，仅在当前 RootTask 缺少边界时使用。
      * @return 优先返回顶部子任务边界；缺失时返回 RootTask 自身边界。
      */
     @Nullable
     private static Rect getTopChildBoundsOrRootBounds(
-            @Nullable ActivityTaskManager.RootTaskInfo focusedRootTaskInfo
+            ActivityTaskManager.RootTaskInfo rootTaskInfo,
+            @Nullable ActivityTaskManager.RootTaskInfo fallbackRootTaskInfo
     ) {
-        if (focusedRootTaskInfo == null) {
-            return null;
-        }
-        final Rect[] childTaskBounds = focusedRootTaskInfo.childTaskBounds;
+        final Rect[] childTaskBounds = rootTaskInfo.childTaskBounds;
         if (childTaskBounds != null && childTaskBounds.length > 0) {
             return childTaskBounds[childTaskBounds.length - 1];
         }
-        return focusedRootTaskInfo.bounds;
+        if (rootTaskInfo.bounds != null) {
+            return rootTaskInfo.bounds;
+        }
+        if (fallbackRootTaskInfo == null) {
+            return null;
+        }
+        final Rect[] fallbackChildTaskBounds = fallbackRootTaskInfo.childTaskBounds;
+        if (fallbackChildTaskBounds != null && fallbackChildTaskBounds.length > 0) {
+            return fallbackChildTaskBounds[fallbackChildTaskBounds.length - 1];
+        }
+        return fallbackRootTaskInfo.bounds;
     }
 }

--- a/hiddenapi/stub/src/main/aidl/android/app/IActivityTaskManager.aidl
+++ b/hiddenapi/stub/src/main/aidl/android/app/IActivityTaskManager.aidl
@@ -2,9 +2,11 @@ package android.app;
 
 import android.app.ITaskStackListener;
 import android.app.ActivityTaskManager;
+import android.graphics.Rect;
 
 interface IActivityTaskManager {
     void registerTaskStackListener(in ITaskStackListener listener);
     void unregisterTaskStackListener(in ITaskStackListener listener);
     ActivityTaskManager.RootTaskInfo getFocusedRootTaskInfo();
+    Rect getTaskBounds(int taskId);
 }

--- a/hiddenapi/stub/src/main/java/android/app/ActivityTaskManager.java
+++ b/hiddenapi/stub/src/main/java/android/app/ActivityTaskManager.java
@@ -1,11 +1,19 @@
 package android.app;
 
+import android.graphics.Rect;
 import android.os.Parcel;
 import android.os.Parcelable;
 
 public class ActivityTaskManager {
 
     public static class RootTaskInfo extends TaskInfo implements Parcelable {
+        public Rect bounds;
+        public int[] childTaskIds;
+        public String[] childTaskNames;
+        public Rect[] childTaskBounds;
+        public int[] childTaskUserIds;
+        public boolean visible;
+        public int position;
 
         protected RootTaskInfo(Parcel in) {
         }

--- a/server/src/main/java/yangfentuozi/batteryrecorder/server/recorder/Monitor.kt
+++ b/server/src/main/java/yangfentuozi/batteryrecorder/server/recorder/Monitor.kt
@@ -49,7 +49,7 @@ class Monitor(
     private val taskStackListener: ITaskStackListener = object : TaskStackListener() {
         @Keep
         override fun onTaskMovedToFront(taskInfo: RunningTaskInfo) {
-            onFocusedAppChanged(taskInfo, getFocusedRootTaskInfo(), "task-moved")
+            onFocusedAppChanged(taskInfo, getFocusedRootTaskInfoOrNull(), "task-moved")
         }
     }
 
@@ -362,6 +362,7 @@ class Monitor(
      * 记录当前聚焦任务对应的前台应用诊断日志，并在满足记录条件时更新缓存包名。
      *
      * @param taskInfo 当前收到的任务栈信息，用于提取任务 ID 与顶部 Activity。
+     * @param focusedRootTaskInfo 当前聚焦 RootTask 信息，用于读取最大窗口边界。
      * @param source 本次前台变更的事件来源，便于区分初始化与任务切换场景。
      * @return 无；当顶部 Activity 为空或命中小窗规则时仅输出日志，不更新当前前台应用缓存。
      */
@@ -375,7 +376,8 @@ class Monitor(
         val bounds = try {
             TaskInfoCompat.getBoundsOrNull(iActivityTaskManager, taskInfo, focusedRootTaskInfo)
         } catch (e: RemoteException) {
-            throw RuntimeException("前台应用检测: 获取任务窗口边界失败", e)
+            LoggerX.e(tag, "前台应用检测: 获取任务窗口边界失败, 跳过本次前台应用更新", tr = e)
+            return
         }
         val maxBounds = TaskInfoCompat.getMaxBoundsOrNull(focusedRootTaskInfo)
         val boundsText = formatRect(bounds)
@@ -457,10 +459,11 @@ class Monitor(
         return "[${rect.left},${rect.top},${rect.right},${rect.bottom}]"
     }
 
-    private fun getFocusedRootTaskInfo(): RootTaskInfo = try {
+    private fun getFocusedRootTaskInfoOrNull(): RootTaskInfo? = try {
         iActivityTaskManager.getFocusedRootTaskInfo()
     } catch (e: RemoteException) {
-        throw RuntimeException("前台应用检测: 获取当前焦点 RootTask 信息失败", e)
+        LoggerX.e(tag, "前台应用检测: 获取当前焦点 RootTask 信息失败, 跳过本次前台应用更新", tr = e)
+        null
     }
 
     // 耗时操作

--- a/server/src/main/java/yangfentuozi/batteryrecorder/server/recorder/Monitor.kt
+++ b/server/src/main/java/yangfentuozi/batteryrecorder/server/recorder/Monitor.kt
@@ -1,6 +1,7 @@
 package yangfentuozi.batteryrecorder.server.recorder
 
 import android.app.ActivityManager.RunningTaskInfo
+import android.app.ActivityTaskManager.RootTaskInfo
 import android.app.IActivityTaskManager
 import android.app.ITaskStackListener
 import android.app.TaskInfo
@@ -48,7 +49,7 @@ class Monitor(
     private val taskStackListener: ITaskStackListener = object : TaskStackListener() {
         @Keep
         override fun onTaskMovedToFront(taskInfo: RunningTaskInfo) {
-            onFocusedAppChanged(taskInfo, "task-moved")
+            onFocusedAppChanged(taskInfo, getFocusedRootTaskInfo(), "task-moved")
         }
     }
 
@@ -266,7 +267,8 @@ class Monitor(
         }
 
         try {
-            onFocusedAppChanged(iActivityTaskManager.getFocusedRootTaskInfo(), "init")
+            val focusedRootTaskInfo = iActivityTaskManager.getFocusedRootTaskInfo()
+            onFocusedAppChanged(focusedRootTaskInfo, focusedRootTaskInfo, "init")
         } catch (e: RemoteException) {
             throw RuntimeException("start: 获取当前焦点任务信息失败", e)
         }
@@ -363,11 +365,19 @@ class Monitor(
      * @param source 本次前台变更的事件来源，便于区分初始化与任务切换场景。
      * @return 无；当顶部 Activity 为空或命中小窗规则时仅输出日志，不更新当前前台应用缓存。
      */
-    private fun onFocusedAppChanged(taskInfo: TaskInfo, source: String) {
+    private fun onFocusedAppChanged(
+        taskInfo: TaskInfo,
+        focusedRootTaskInfo: RootTaskInfo?,
+        source: String
+    ) {
         val oldForegroundApp = currForegroundApp
         val componentName = taskInfo.topActivity
-        val bounds = TaskInfoCompat.getBoundsOrNull(taskInfo)
-        val maxBounds = TaskInfoCompat.getMaxBoundsOrNull(taskInfo)
+        val bounds = try {
+            TaskInfoCompat.getBoundsOrNull(iActivityTaskManager, taskInfo, focusedRootTaskInfo)
+        } catch (e: RemoteException) {
+            throw RuntimeException("前台应用检测: 获取任务窗口边界失败", e)
+        }
+        val maxBounds = TaskInfoCompat.getMaxBoundsOrNull(focusedRootTaskInfo)
         val boundsText = formatRect(bounds)
         val maxBoundsText = formatRect(maxBounds)
         if (componentName == null) {
@@ -445,6 +455,12 @@ class Monitor(
     private fun formatRect(rect: Rect?): String {
         if (rect == null) return "unavailable"
         return "[${rect.left},${rect.top},${rect.right},${rect.bottom}]"
+    }
+
+    private fun getFocusedRootTaskInfo(): RootTaskInfo = try {
+        iActivityTaskManager.getFocusedRootTaskInfo()
+    } catch (e: RemoteException) {
+        throw RuntimeException("前台应用检测: 获取当前焦点 RootTask 信息失败", e)
     }
 
     // 耗时操作


### PR DESCRIPTION
- 在 `IActivityTaskManager.aidl` 中添加 `getTaskBounds` 接口。
- 重构 `TaskInfoCompat`，移除反射逻辑，改为通过 `IActivityTaskManager` 和 `RootTaskInfo` 获取任务边界。
- 更新 `Monitor` 类，在应用焦点变化时引入 `RootTaskInfo` 以更准确地计算窗口范围。
- 完善 `ActivityTaskManager.RootTaskInfo` 的 Stub 定义，补充 `childTaskBounds` 等必要字段。